### PR TITLE
I think maybe this should be a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This tool creates files from Alliance resources. The tool is build and testsed w
 ## Running Tool Example command
 
 ```bash
-export ALLIANCE_DATABASEB_VERSION='2.0.0'
+export ALLIANCE_DATABASE_VERSION='2.0.0'
 export NEO4J_HOST=build.alliancegenome.org
 python src/app.py 
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This tool creates files from Alliance resources. The tool is build and testsed w
 ## Running Tool Example command
 
 ```bash
-export ALLIANCE_DB_VERSION=2.0.0
+export ALLIANCE_DATABASEB_VERSION='2.0.0'
 export NEO4J_HOST=build.alliancegenome.org
 python src/app.py 
 ```

--- a/src/app.py
+++ b/src/app.py
@@ -13,7 +13,7 @@ else:
 
 uri = "bolt://" + host + ":" + str(port)
 
-if "ALLIANCE_DB_VERSION" in os.environ:
+if "ALLIANCE_DATABASE_VERSION" in os.environ:
     alliance_db_version = int(os.environ['ALLIANCE_DATABASE_VERSION'])
 else:
     alliance_db_version = "test"


### PR DESCRIPTION
Was getting this:

```
export ALLIANCE_DB_VERSION=2.0.0
export NEO4J_HOST=build.alliancegenome.org
python src/app.py
Traceback (most recent call last):
  File "src/app.py", line 17, in <module>
    alliance_db_version = int(os.environ['ALLIANCE_DATABASE_VERSION'])
  File "/Users/nathandunn/repositories/agr_file_generator/V1/bin/../lib/python3.7/os.py", line 678, in __getitem__
    raise KeyError(key) from None
KeyError: 'ALLIANCE_DATABASE_VERSION'
```

fixed and now getting this:

```
python src/app.py                         
Traceback (most recent call last):
  File "src/app.py", line 17, in <module>
    alliance_db_version = int(os.environ['ALLIANCE_DATABASE_VERSION'])
ValueError: invalid literal for int() with base 10: '2.0.0'
```