### PR TITLE
Added logging

### DIFF
--- a/src/agr/app.py
+++ b/src/agr/app.py
@@ -1,6 +1,8 @@
+import logging
 import os
 
 from agr.vcf_file_generator import VcfFileGenerator
+import agr.assembly_sequence as agr_asm_seq
 from agr.data_source import DataSource
 
 
@@ -12,8 +14,24 @@ alliance_db_version = os.environ.get('ALLIANCE_DATABASE_VERSION', 'test')
 
 uri = "bolt://" + host + ":" + str(port)
 
-def main(generated_files_folder='generated_files'):
+assembly_to_s3_uri = {
+    'R6.27': 'https://s3.amazonaws.com/agrjbrowse/FlyBase/fruitfly/fasta/',
+    'GRCz11': 'https://s3.amazonaws.com/agrjbrowse/zfin/zebrafish/fasta/',
+    'WBcel235': 'https://s3.amazonaws.com/agrjbrowse/WormBase/c_elegans_PRJNA13758/fasta/',
+    'Rnor_6.0': 'https://s3.amazonaws.com/agrjbrowse/RGD/rat/fasta/',
+    'GRCm38': 'https://s3.amazonaws.com/agrjbrowse/MGI/mouse/fasta/'
+}
+
+
+def setup_logging(logger_name):
+    logging.basicConfig(level=logging.DEBUG)
+
+
+def main(generated_files_folder='generated_files',
+         fasta_sequences_folder='sequences',
+         skip_chromosomes={'Unmapped_Scaffold_8_D1580_D1567'}):
     os.makedirs(generated_files_folder, exist_ok=True)
+    os.makedirs(fasta_sequences_folder, exist_ok=True)
     variants_query = """MATCH (s:Species)-[:FROM_SPECIES]-(a:Allele)-[:VARIATION]-(v:Variant)-[l:LOCATED_ON]-(c:Chromosome)
 MATCH (v:Variant)-[:VARIATION_TYPE]-(st:SOTerm)
 RETURN c.primaryKey AS chromosome,
@@ -30,8 +48,12 @@ RETURN c.primaryKey AS chromosome,
        st.nameKey AS soTerm
     """
     data_source = DataSource(uri, variants_query)
-    gvf = VcfFileGenerator(data_source, generated_files_folder, alliance_db_version)
-    gvf.generate_files()
+    agr_asm_seq.ensure_downloaded(fasta_sequences_folder, assembly_to_s3_uri)
+    gvf = VcfFileGenerator(data_source,
+                           generated_files_folder,
+                           fasta_sequences_folder,
+                           alliance_db_version)
+    gvf.generate_files(skip_chromosomes=skip_chromosomes)
 
 
 if __name__ == '__main__':

--- a/src/agr/assembly_sequence.py
+++ b/src/agr/assembly_sequence.py
@@ -1,36 +1,40 @@
+import logging
 import os
 
 import wget
-from pyfaidx import Fasta
 
-class AssemblySequence:
 
-    def __init__(self, assembly, local_assembly_dir='sequences'):
-        self.assembly = assembly
-        local_filepath = os.path.join(local_assembly_dir, assembly + '.fa')
-        if not os.path.isfile(local_filepath):
-            print('Assembly file does not exist:')
-            self.download(assembly, local_assembly_dir, local_filepath)
-        self.fa = Fasta(local_filepath)
+logger = logging.getLogger(name=__name__)
 
-    @classmethod
-    def download(cls, assembly, local_assembly_dir, local_filepath):
-        assembly_to_s3_dict = {
-            'R6.27': 'https://s3.amazonaws.com/agrjbrowse/FlyBase/fruitfly/fasta/',
-            'GRCz11': 'https://s3.amazonaws.com/agrjbrowse/zfin/zebrafish/fasta/',
-            'WBcel235': 'https://s3.amazonaws.com/agrjbrowse/WormBase/c_elegans_PRJNA13758/fasta/',
-            'Rnor_6.0': 'https://s3.amazonaws.com/agrjbrowse/RGD/rat/fasta/',
-            'GRCm38': 'https://s3.amazonaws.com/agrjbrowse/MGI/mouse/fasta/'
-        }
-        url = assembly_to_s3_dict[assembly] + assembly + '.fa'
-        if not os.path.exists(local_assembly_dir):
-            os.makedirs(local_assembly_dir)
-        wget.download(url, out=local_assembly_dir)
 
-    def get(self, chromosome, start, end):
-        start -= 1
-        if chromosome.startswith('chr'):
-            chromosome_str = chromosome[3:]
+def get_local_path(local_assembly_dir, assembly):
+    return os.path.join(local_assembly_dir, assembly + '.fa')
+
+
+def download(local_assembly_dir, s3_uri, assembly):
+    url = s3_uri + assembly + '.fa'
+    os.makedirs(local_assembly_dir, exist_ok=True)
+    download_to = get_local_path(local_assembly_dir, assembly)
+    logger.info('Downloading assembly sequence (FASTA) from %s to %s',
+                url,
+                download_to)
+    wget.download(url, out=local_assembly_dir)
+
+
+def ensure_downloaded(local_assembly_dir, assembly_to_s3_uri):
+    for (ass_name, s3_uri) in assembly_to_s3_uri.items():
+        local_path = get_local_path(local_assembly_dir, ass_name)
+        if os.path.exists(local_path):
+            logger.warning('Assembly Sequence already downloaded for %r, skipping',
+                           ass_name)
         else:
-            chromosome_str = chromosome
-        return self.fa[chromosome_str][start:end].seq
+            download(local_assembly_dir, s3_uri, ass_name)
+
+
+def get_seq(fasta, chromosome, start, end):
+    start -= 1
+    if chromosome.startswith('chr'):
+        chromosome_str = chromosome[3:]
+    else:
+        chromosome_str = chromosome
+    return fasta[chromosome_str][start:end].seq


### PR DESCRIPTION
Used logging module from std library instead of `print` and `exit`.

Logging is currently configured via a call to `logging.basicLogging` in `agr.app`,
this could be augmented to support logging to a file for example.

Refactored `agr.assembly_sequence` module to have a functional interface rather use a class.

Fixes #5