### PR TITLE
Prevent code from running twice under test.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=INSTALL_REQUIRES,
     entry_points={
         'console_scripts': [
-            'agr_file_generator=agr.__main__:main',
+            'agr_file_generator=agr.app:main',
         ],
         # TOOD: add hooks for docs generation?
         # 'zest.releaser.releaser.after': [

--- a/src/agr/__main__.py
+++ b/src/agr/__main__.py
@@ -1,5 +1,0 @@
-
-from agr.app import main
-
-# TODO: use argparse/getopt
-main()

--- a/src/agr/app.py
+++ b/src/agr/app.py
@@ -83,8 +83,11 @@ RETURN gene1.primaryKey AS gene1ID,
        species2.primaryKey AS species2TaxonID,
        species2.name AS species2Name"""
     data_source = DataSource(uri, orthology_query)
-    of = OrthologyFileGenerator(data_source, 
+    of = OrthologyFileGenerator(data_source,
                                 generated_files_folder,
                                 alliance_db_version)
     of.generate_file()
 
+
+if  __name__ == '__main__':
+    main()

--- a/src/agr/app.py
+++ b/src/agr/app.py
@@ -6,7 +6,6 @@ from agr.orthology_file_generator import OrthologyFileGenerator
 import agr.assembly_sequence as agr_asm_seq
 from agr.data_source import DataSource
 
-
 host = os.environ.get('NEO4J_HOST', 'localhost')
 
 port = int(os.environ.get('NEO4J_PORT', 7687))
@@ -33,7 +32,6 @@ def main(generated_files_folder='generated_files',
          skip_chromosomes={'Unmapped_Scaffold_8_D1580_D1567'}):
     #  generate_vcf_files(generated_files_folder, fasta_sequences_folder, skip_chromosomes)
     generate_orthology_file(generated_files_folder, alliance_db_version)
-    exit()
 
 
 def generate_vcf_files(generated_files_folder, fasta_sequences_folder, skip_chromosomes):
@@ -90,6 +88,3 @@ RETURN gene1.primaryKey AS gene1ID,
                                 alliance_db_version)
     of.generate_file()
 
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
The issue of running twice is because the test framework `pytest` was including the `__main__` module when collecting code to import.

This PR removes the `__main__` module, changing the entry point in setup.py to `agr.app:main` directly.
Another option would have been to pass `--exclude=__main__.py` to the test runner, but I think this is cleaner.