### PR TITLE
added tab delimited file generation

### DIFF
--- a/src/generators/vcf_file_generator.py
+++ b/src/generators/vcf_file_generator.py
@@ -54,6 +54,14 @@ class VcfFileGenerator:
         vcf_file.write('\n')
 
     @classmethod
+    def _write_tab_delimited_header(cls, tab_delimited_file, assembly, species, config_info):
+        dt = time.strftime("%Y%m%d", time.gmtime())
+        tab_delimited_file.write(dt)
+        tab_delimited_file.write('\n')
+        tab_delimited_file.write('HGVS\tConsequence\tSymbol\tAlleles\tAllele of genes\tSymbol (text)')
+        tab_delimited_file.write('\n')
+
+    @classmethod
     def _variant_value_for_file(cls, variant, data_key, transform=None):
         value = variant.get(data_key)
         if value is None:
@@ -92,6 +100,26 @@ class VcfFileGenerator:
                                   info]))
         vcf_file.write('\n')
 
+    @classmethod
+    def _add_variant_to_tab_file(cls, tab_delimited_file, variant):
+        info_map = OrderedDict()
+        info_map['hgvs_nomenclature'] = cls._variant_value_for_file(variant, 'hgvsNomenclature')
+        if cls._variant_value_for_file(variant, 'geneLevelConsequence') is not None:
+            info_map['geneLevelConsequence'] = ' '.join(cls._variant_value_for_file(variant, 'geneLevelConsequence').split('_'))
+        else:
+            info_map['geneLevelConsequence'] = cls._variant_value_for_file(variant, 'geneLevelConsequence')
+        info_map['symbol'] = cls._variant_value_for_file(variant, 'symbol')
+        info_map['globalId'] = variant['globalId']
+        info_map['alleles'] = cls._variant_value_for_file(variant,'alleles',transform=', '.join)
+        info_map['allele_of_genes'] = cls._variant_value_for_file(variant, 'geneSymbol', transform=', '.join)
+        info_map['symbol_text'] = cls._variant_value_for_file(variant, 'symbolText')
+        if any(info_map.values()):
+            info = '\t'.join(v for (k, v) in info_map.items() if v)
+        else:
+            info = cls.empty_value_marker
+        tab_delimited_file.write(info)
+        tab_delimited_file.write('\n')
+
     def _consume_data_source(self):
         assembly_chr_variants = defaultdict(lambda: defaultdict(list))
         assembly_species = {}
@@ -117,7 +145,7 @@ class VcfFileGenerator:
                 self._add_padded_base_to_variant(variant, 'deletion')
         elif so_term == 'insertion':
             if variant['genomicReferenceSequence'] != '':
-                logger.error('Insertion Variant reference sequence is populated '
+                logger.error('Insertion Variant reference sequence is populated'
                              'when it should not be in '
                              'variant ID: %r',
                              variant['ID'])
@@ -141,20 +169,33 @@ class VcfFileGenerator:
         for (assembly, chromo_variants) in assembly_chr_variants.items():
             logger.info('Generating VCF File for assembly %r', assembly)
             filename = assembly + '-' + self.config_info.config['RELEASE_VERSION'] + '.vcf'
+            tab_filename = assembly + '-' + self.config_info.config['RELEASE_VERSION'] + '.txt'
             filepath = os.path.join(self.generated_files_folder, filename)
+            filepath_tab = os.path.join(self.generated_files_folder, tab_filename)
             with open(filepath, 'w') as vcf_file:
-                self._write_vcf_header(vcf_file,
-                                       assembly,
+                self._write_vcf_header(vcf_file, assembly,
                                        assembly_species[assembly],
                                        self.config_info)
                 for (chromosome, variants) in sorted(chromo_variants.items(), key=itemgetter(0)):
                     if chromosome in skip_chromosomes:
-                        logger.info('Skipping VCF file generation for chromosome %r',chromosome)
+                        logger.info('Skipping VCF file generation for chromosome %r', chromosome)
                         continue
                     adjust_varient = partial(self._adjust_variant)
                     adjusted_variants = filter(None, map(adjust_varient, variants))
                     for variant in sorted(adjusted_variants, key=itemgetter('POS')):
                         self._add_variant_to_vcf_file(vcf_file, variant)
+            with open(filepath_tab, 'w') as tab_delimited_file:
+                self._write_tab_delimited_header(tab_delimited_file, assembly, 
+                                                 assembly_species[assembly],
+                                                 self.config_info)
+                for (chromosome, variants) in sorted(chromo_variants.items(), key=itemgetter(0)):
+                    if chromosome in skip_chromosomes:
+                        logger.info('Skipping tab delimited file generation for chromosome %r', chromosome)
+                        continue
+                    adjust_varient = partial(self._adjust_variant)
+                    adjusted_variants = filter(None, map(adjust_varient, variants))
+                    for variant in sorted(adjusted_variants, key=itemgetter('POS')):
+                        self._add_variant_to_tab_file(tab_delimited_file, variant)
             if upload_flag:
                 logger.info("Submitting to FMS")
                 process_name = "1"


### PR DESCRIPTION
I added the tab delimited generation to the VCF procedure.  Files are generated at the same time and on the same directory, identical naming, with extension `txt` and contain the same information as the INFO column from the VCFs.

We can add this as feature or keep the branch there. These tab delimited files were requested at the variants meeting, just for checking annotation.