### PR TITLE
AGR-1940 and AGR-1841 - Splitting disease and expression files into taxon specific files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ retry==0.9.2
 urllib3==1.24.2
 coloredlogs==10.0
 PyYAML==5.1
+json5==0.8.5

--- a/src/generators/daf_file_generator.py
+++ b/src/generators/daf_file_generator.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime
 from time import gmtime, strftime
 
+import json
 import csv
 import upload
 
@@ -16,55 +17,52 @@ class DafFileGenerator:
 # Disease Association Format (DAF)
 # Source: Alliance of Genome Resources (Alliance)
 # Orthology Filter: Stringent
+# TaxonIDs: {taxonIDs}
 # Datebase Version: {databaseVersion}
 # Date: {datetimeNow}
 #
 #########################################################################
 """
 
-    def __init__(self, disease_associations, generated_files_folder, config_info):
+    def __init__(self, disease_associations, generated_files_folder, config_info, taxon_id_fms_subtype_map):
         self.disease_associations = disease_associations
         self.config_info = config_info
+        self.taxon_id_fms_subtype_map = taxon_id_fms_subtype_map
         self.generated_files_folder = generated_files_folder
 
     @classmethod
-    def _generate_header(cls, config_info):
-        return cls.file_header_template.format(datetimeNow=strftime("%Y-%m-%d %H:%M:%S", gmtime()),
+    def _generate_header(cls, config_info, taxon_ids):
+        return cls.file_header_template.format(taxonIDs=",".join(taxon_ids),
+                                               datetimeNow=strftime("%Y-%m-%d %H:%M:%S", gmtime()),
                                                databaseVersion=config_info.config['RELEASE_VERSION'])
 
     def generate_file(self, upload_flag=False):
-        filename = "agr-daf-" + self.config_info.config['RELEASE_VERSION'] + ".tsv"
-        output_filepath = os.path.join(self.generated_files_folder, filename)
-        disease_file = open(output_filepath,'w')
-        disease_file.write(self._generate_header(self.config_info))
+        fields = ["Taxon",
+                  "SpeciesName",
+                  "DBobjectType",
+                  "DBObjectID",
+                  "DBObjectSymbol",
+                  #"InferredGeneAssociation",
+                  #"GeneProductFormID",
+                  #"AdditionalGeneticComponent",
+                  #"ExperimentalConditions",
+                  "AssociationType",
+                  #"Qualifier",
+                  "DOID",
+                  "DOname",
+                  "withOrthologs",
+                  #"Modifier-AssociationType",
+                  #"Modifier-Qualifier",
+                  #"Modifier-Genetic",
+                  #"Modifier-ExperimentalConditions",
+                  "EvidenceCode",
+                  #"genetic-sex",
+                  "Reference",
+                  "Date",
+                  "Source"]
 
-        columns = ["Taxon",
-                   "SpeciesName",
-                   "DBobjectType",
-                   "DBObjectID",
-                   "DBObjectSymbol",
-                   #"InferredGeneAssociation",
-                   #"GeneProductFormID",
-                   #"AdditionalGeneticComponent",
-                   #"ExperimentalConditions",
-                   "AssociationType",
-                   #"Qualifier",
-                   "DOID",
-                   "DOname",
-                   "withOrthologs",
-                   #"Modifier-AssociationType",
-                   #"Modifier-Qualifier",
-                   #"Modifier-Genetic",
-                   #"Modifier-ExperimentalConditions",
-                   "EvidenceCode",
-                   #"genetic-sex",
-                   "Reference",
-                   "Date",
-                   "Source"]
-
-        tsv_writer = csv.DictWriter(disease_file, delimiter='\t', fieldnames=columns, lineterminator="\n")
-        tsv_writer.writeheader()
-
+        processed_disease_associations = {}
+        processed_disease_associations_tsv = {}
         for disease_association in self.disease_associations:
             db_object_type = "allele" if disease_association["objectType"][0] == "Feature" else disease_association["objectType"][0].lower()
             pub_id = disease_association["pubMedID"] if disease_association["pubMedID"] else disease_association["pubModID"]
@@ -94,36 +92,83 @@ class DafFileGenerator:
             # genetic_sex = ""
             if disease_association["dateAssigned"] is None and disease_association["associationType"] in ["IMPLICATED_VIA_ORTHOLOGY",
                                                                                                           "BIOMARKER_VIA_ORTHOLOGY"]:
-                date_str = strftime("%Y-%m-%d %H:%M:%S", gmtime())
+                date_str = strftime("%Y-%m-%dT%H:%M:%S", gmtime())
             else:
                 date_str = disease_association["dateAssigned"]
 
-            row = dict(zip(columns, [disease_association["taxonId"],
-                                     disease_association["speciesName"],
-                                     db_object_type,
-                                     disease_association["dbObjectID"],
-                                     disease_association["dbObjectSymbol"],
-                                     #inferred_gene_association,
-                                     #gene_product_form_id,
-                                     #additional_genetic_component,
-                                     #experimental_conditions,
-                                     disease_association["associationType"].lower(),
-                                     #qualifier,
-                                     disease_association["DOID"],
-                                     do_name,
-                                     with_orthologs,
-                                     #modifier_association_type,
-                                     #modifier_qualifier,
-                                     #modifier_genetic,
-                                     #modifier_experimental_conditions,
-                                     evidence_code,
-                                     #genetic_sex,
-                                     pub_id,
-                                     datetime.strptime(date_str[:10], "%Y-%m-%d").strftime("%Y%m%d"),
-                                     disease_association["dataProvider"]]))
-            tsv_writer.writerows([row])
-        disease_file.close()
+            taxon_id = disease_association["taxonId"]
+            taxon_id = taxon_id.replace("NCBITaxonId", "NCBI:txid")
+            processed_association = dict(zip(fields, [taxon_id,
+                                                      disease_association["speciesName"],
+                                                      db_object_type,
+                                                      disease_association["dbObjectID"],
+                                                      disease_association["dbObjectSymbol"],
+                                                      #inferred_gene_association,
+                                                      #gene_product_form_id,
+                                                      #additional_genetic_component,
+                                                      #experimental_conditions,
+                                                      disease_association["associationType"].lower(),
+                                                      #qualifier,
+                                                      disease_association["DOID"],
+                                                      do_name,
+                                                      disease_association["withOrthologs"],
+                                                      #modifier_association_type,
+                                                      #modifier_qualifier,
+                                                      #modifier_genetic,
+                                                      #modifier_experimental_conditions,
+                                                      evidence_code,
+                                                      #genetic_sex,
+                                                      pub_id,
+                                                      datetime.strptime(date_str[:10], "%Y-%m-%d").strftime("%Y%m%d"),
+                                                      disease_association["dataProvider"]]))
+            processed_association_tsv = processed_association.copy()
+            processed_association_tsv["withOrthologs"] = with_orthologs
+            if taxon_id in processed_disease_associations:
+                processed_disease_associations_tsv[taxon_id].append(processed_association_tsv)
+                processed_disease_associations[taxon_id].append(processed_association)
+            else:
+                processed_disease_associations_tsv[taxon_id] = [processed_association_tsv]
+                processed_disease_associations[taxon_id] = [processed_association]
+
+        file_basename = "agr-daf-" + self.config_info.config['RELEASE_VERSION']
+        combined_file_basepath = os.path.join(self.generated_files_folder, file_basename + '.combined')
+
+        combined_filepath_tsv = combined_file_basepath + '.tsv'
+        combined_disease_file = open(combined_filepath_tsv, 'w')
+        combined_disease_file.write(self._generate_header(self.config_info, set(processed_disease_associations.keys())))
+        combined_tsv_writer = csv.DictWriter(combined_disease_file, delimiter='\t', fieldnames=fields, lineterminator="\n")
+        combined_tsv_writer.writeheader()
+
+        combined_filepath_json = combined_file_basepath + '.json'
+        with open(combined_filepath_json, 'w') as outfile:
+            json.dump(sum(processed_disease_associations.values(), []), outfile)
+
+        for taxon_id in processed_disease_associations:
+            combined_tsv_writer.writerows(processed_disease_associations[taxon_id])
+
+            taxon_file_basepath = os.path.join(self.generated_files_folder, file_basename + '.' + taxon_id)
+            taxon_filepath_json = taxon_file_basepath + '.json'
+            with open(taxon_filepath_json, 'w') as f:
+                json.dump(processed_disease_associations[taxon_id], f)
+
+            taxon_filename_tsv = taxon_file_basepath + '.tsv'
+            with open(taxon_filename_tsv, 'w') as f:
+                f.write(self._generate_header(self.config_info, taxon_id))
+                tsv_writer = csv.DictWriter(f, delimiter='\t', fieldnames=fields, lineterminator="\n")
+                tsv_writer.writeheader()
+                tsv_writer.writerows(processed_disease_associations_tsv[taxon_id])
+
+        combined_disease_file.close()
+
         if upload_flag:
-            logger.info("Submitting to FMS")
+            logger.info("Submitting disease files to FMS")
             process_name = "1"
-            upload.upload_process(process_name, filename, self.generated_files_folder, 'DISEASE-ALLIANCE', 'COMBINED', self.config_info)
+            upload.upload_process(process_name, combined_filepath_tsv, self.generated_files_folder, 'DISEASE-ALLIANCE', 'COMBINED', self.config_info)
+            upload.upload_process(process_name, combined_filepath_json, self.generated_files_folder, 'DISEASE-ALLIANCE-JSON', 'COMBINED', self.config_info)
+            for taxon_id in processed_disease_associations:
+                 for file_extension in ['json', 'tsv']:
+                     filename = file_basename + "." + taxon_id + '.' + file_extension
+                     datatype = "DISEASE-ALLIANCE"
+                     if file_extension == "json":
+                          datatype += "-JSON"
+                     upload.upload_process(process_name, filename, self.generated_files_folder, datatype, self.taxon_id_fms_subtype_map[taxon_id], self.config_info)

--- a/src/generators/expression_file_generator.py
+++ b/src/generators/expression_file_generator.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import json
 import csv
 from time import gmtime, strftime
 
@@ -14,128 +15,165 @@ class ExpressionFileGenerator:
 #
 # Expression
 # Source: Alliance of Genome Resources (Alliance)
+# TaxonIDs: {taxonIDs}
 # Datebase Version: {databaseVersion}
 # Date: {datetimeNow}
 #
 #########################################################################
 """
 
-    def __init__(self, expressions, generated_files_folder, config_info):
+    def __init__(self, expressions, generated_files_folder, config_info, taxon_id_fms_subtype_map):
         self.expressions = expressions
         self.config_info = config_info
+        self.taxon_id_fms_subtype_map = taxon_id_fms_subtype_map
         self.generated_files_folder = generated_files_folder
 
     @classmethod
-    def _generate_header(cls, config_info):
-        return cls.file_header_template.format(datetimeNow=strftime("%Y-%m-%d %H:%M:%S", gmtime()),
+    def _generate_header(cls, config_info, taxon_ids):
+        return cls.file_header_template.format(taxonIDs=",".join(taxon_ids),
+                                               datetimeNow=strftime("%Y-%m-%d %H:%M:%S", gmtime()),
                                                databaseVersion=config_info.config['RELEASE_VERSION'])
 
     def generate_file(self, upload_flag=False):
-        filename = 'agr-expression-' + self.config_info.config['RELEASE_VERSION'] + '.tsv'
-        output_filepath = os.path.join(self.generated_files_folder, filename)
-        expression_file = open(output_filepath,'w')
-        expression_file.write(self._generate_header(self.config_info))
+        fields = ['Species',
+                  'SpeciesID',
+                  'GeneID',
+                  'GeneSymbol',
+                  'Location',
+                 # 'StageID', currently don't have stage IDs in the database
+                  'StageTerm',
+                  'AssayID',
+                  'AssayTermName',
+                  'CellularComponentID',
+                  'CellularComponentTerm',
+                  'CellularComponentQualifierIDs',
+                  'CellularComponentQualifierTermNames',
+                  'SubStructureID',
+                  'SubStructureName',
+                  'SubStructureQualifierIDs',
+                  'SubStructureQualifierTermNames',
+                  'AnatomyTermID',
+                  'AnatomyTermName',
+                  'AnatomyTermQualifierIDs',
+                  'AnatomyTermQualifierTermNames',
+                  'Source',
+                  'Reference']
 
-        columns = ['Species',
-                   'SpeciesID',
-                   'GeneID',
-                   'GeneSymbol',
-                   'Location',
-                  # 'StageID', currently don't have stage IDs in the database
-                   'StageTerm',
-                   'AssayID',
-                   'AssayTermName',
-                   'CellularComponentID',
-                   'CellularComponentTerm',
-                   'CellularComponentQualifierIDs',
-                   'CellularComponentQualifierTermNames',
-                   'SubStructureID',
-                   'SubStructureName',
-                   'SubStructureQualifierIDs',
-                   'SubStructureQualifierTermNames',
-                   'AnatomyTermID',
-                   'AnatomyTermName',
-                   'AnatomyTermQualifierIDs',
-                   'AnatomyTermQualifierTermNames',
-                   'Source',
-                   'Reference']
-
-        tsv_writer = csv.DictWriter(expression_file, delimiter='\t', fieldnames=columns, lineterminator="\n")
-        tsv_writer.writeheader()
+        associations = dict()
         for expression in self.expressions:
-            row = dict(zip(columns, [None] * len(columns)))
-            row['Species'] = expression['species']['name']
-            row['SpeciesID'] = expression['species']['primaryKey']
-            row['GeneID'] = expression['gene']['primaryKey']
-            row['GeneSymbol'] = expression['gene']['symbol']
-            row['Location'] = expression['location']
+            association = dict(zip(fields, [None] * len(fields)))
+            association['Species'] = expression['species']['name']
+            association['SpeciesID'] = expression['species']['primaryKey']
+            association['SpeciesID'] = association['SpeciesID'].replace("NCBITaxonId", "NCBI:txid")
+            association['GeneID'] = expression['gene']['primaryKey']
+            association['GeneSymbol'] = expression['gene']['symbol']
+            association['Location'] = expression['location']
             for term in expression['terms']:
                 if 'CrossReference' in term.labels:
-                    if row['Source']:
-                        row['Source'] += ','
-                        row['Source'] += term['crossRefCompleteUrl']  # according to spec should use globalCrossRefId
+                    if association['Source']:
+                        association['Source'].append(term['crossRefCompleteUrl']) # according to spec should use globalCrossRefId
                     else:
-                        row['Source'] = term['crossRefCompleteUrl']
+                        association['Source'] = [term['crossRefCompleteUrl']]
                 elif 'Publication' in term.labels:
                     publication = term['pubMedId'] or term['pubModId']
-                    # reference = row['Reference']
-                    if row['Reference']:
-                        row['Reference'] += ','
-                        row['Reference'] += publication
+                    # reference = association['Reference']
+                    if association['Reference']:
+                        association['Reference'].append(publication)
                     else:
-                        row['Reference'] = publication
+                        association['Reference'] = [publication]
                 elif 'Stage' in term.labels:
-                    #row['StageID'] = term['primaryKey']
-                    row['StageTerm'] = term['name']
+                    #association['StageID'] = term['primaryKey']
+                    association['StageTerm'] = term['name']
                 elif 'MMOTerm' in term.labels:
-                    row['AssayID'] = term['primaryKey']
-                    row['AssayTermName'] = term['name']
-            for ontologyPath in expression['ontologyPaths']:
-                if ontologyPath['edge'] == 'ANATOMICAL_STRUCTURE':
-                    row['AnatomyTermID'] = ontologyPath['primaryKey']
-                    row['AnatomyTermName'] = ontologyPath['name']
-                elif ontologyPath['edge'] == 'CELLULAR_COMPONENT':
-                    row['CellularComponentID'] = ontologyPath['primaryKey']
-                    row['CellularComponentTerm'] = ontologyPath['name']
-                elif ontologyPath['edge'] == 'ANATOMICAL_SUB_SUBSTRUCTURE':
-                    row['SubStructureID'] = ontologyPath['primaryKey']
-                    row['SubStructureName'] = ontologyPath['name']
-                elif ontologyPath['edge'] == 'CELLULAR_COMPONENT_QUALIFIER':
-                    if row['CellularComponentQualifierIDs']:
-                        row['CellularComponentQualifierIDs'] += ','
-                        row['CellularComponentQualifierIDs'] += ontologyPath['primaryKey']
+                    association['AssayID'] = term['primaryKey']
+                    association['AssayTermName'] = term['name']
+            for ontology_path in expression['ontologyPaths']:
+                if ontology_path['edge'] == 'ANATOMICAL_STRUCTURE':
+                    association['AnatomyTermID'] = ontology_path['primaryKey']
+                    association['AnatomyTermName'] = ontology_path['name']
+                elif ontology_path['edge'] == 'CELLULAR_COMPONENT':
+                    association['CellularComponentID'] = ontology_path['primaryKey']
+                    association['CellularComponentTerm'] = ontology_path['name']
+                elif ontology_path['edge'] == 'ANATOMICAL_SUB_SUBSTRUCTURE':
+                    association['SubStructureID'] = ontology_path['primaryKey']
+                    association['SubStructureName'] = ontology_path['name']
+                elif ontology_path['edge'] == 'CELLULAR_COMPONENT_QUALIFIER':
+                    if association['CellularComponentQualifierIDs']:
+                        association['CellularComponentQualifierIDs'].append(ontology_path['primaryKey'])
                     else:
-                        row['CellularComponentQualifierIDs'] = ontologyPath['primaryKey']
-                    if row['CellularComponentQualifierTermNames']:
-                        row['CellularComponentQualifierTermNames'] += ','
-                        row['CellularComponentQualifierTermNames'] += ontologyPath['name']
+                        association['CellularComponentQualifierIDs'] = [ontology_path['primaryKey']]
+                    if association['CellularComponentQualifierTermNames']:
+                        association['CellularComponentQualifierTermNames'].append(ontology_path['name'])
                     else:
-                        row['CellularComponentQualifierTermNames'] = ontologyPath['name']
-                elif ontologyPath['edge'] == 'ANATOMICAL_SUB_STRUCTURE_QUALIFIER':
-                    if row['SubStructureQualifierIDs']:
-                        row['SubStructureQualifierIDs'] += ','
-                        row['SubStructureQualifierIDs'] += ontologyPath['primaryKey']
+                        association['CellularComponentQualifierTermNames'] = [ontology_path['name']]
+                elif ontology_path['edge'] == 'ANATOMICAL_SUB_STRUCTURE_QUALIFIER':
+                    if association['SubStructureQualifierIDs']:
+                        association['SubStructureQualifierIDs'].append(ontology_path['primaryKey'])
                     else:
-                        row['SubStructureQualifierIDs'] = ontologyPath['primaryKey']
-                    if row['SubStructureQualifierTermNames']:
-                        row['SubStructureQualifierTermNames'] += ','
-                        row['SubStructureQualifierTermNames'] += ontologyPath['name']
+                        association['SubStructureQualifierIDs'] = [ontology_path['primaryKey']]
+                    if association['SubStructureQualifierTermNames']:
+                        association['SubStructureQualifierTermNames'].append(ontology_path['name'])
                     else:
-                        row['SubStructureQualifierTermNames'] = ontologyPath['name']
-                elif ontologyPath['edge'] == 'ANATOMICAL_STRUCTURE_QUALIFIER':
-                    if row['AnatomyTermQualifierIDs']:
-                        row['AnatomyTermQualifierIDs'] += ','
-                        row['AnatomyTermQualifierIDs'] += ontologyPath['primaryKey']
+                        association['SubStructureQualifierTermNames'] = [ontology_path['name']]
+                elif ontology_path['edge'] == 'ANATOMICAL_STRUCTURE_QUALIFIER':
+                    if association['AnatomyTermQualifierIDs']:
+                        association['AnatomyTermQualifierIDs'].append(ontology_path['primaryKey'])
                     else:
-                        row['AnatomyTermQualifierIDs'] = ontologyPath['primaryKey']
-                    if row['AnatomyTermQualifierTermNames']:
-                        row['AnatomyTermQualifierTermNames'] += ','
-                        row['AnatomyTermQualifierTermNames'] += ontologyPath['name']
+                        association['AnatomyTermQualifierIDs'] = [ontology_path['primaryKey']]
+                    if association['AnatomyTermQualifierTermNames']:
+                        association['AnatomyTermQualifierTermNames'].append(ontology_path['name'])
                     else:
-                        row['AnatomyTermQualifierTermNames'] = ontologyPath['name']
-            tsv_writer.writerows([row])
-        expression_file.close()
+                        association['AnatomyTermQualifierTermNames'].append(ontology_path['name'])
+                taxon_id = association['SpeciesID']
+                if taxon_id in associations:
+                    associations[taxon_id].append(association)
+                else:
+                    associations[taxon_id] = [association]
+
+        file_basename = "agr-expression-" + self.config_info.config['RELEASE_VERSION']
+        combined_file_basepath = os.path.join(self.generated_files_folder, file_basename + '.combined')
+
+        combined_filepath_tsv = combined_file_basepath + '.tsv'
+        combined_expression_file = open(combined_filepath_tsv, 'w')
+        combined_expression_file.write(self._generate_header(self.config_info, set(associations.keys())))
+        combined_tsv_writer = csv.DictWriter(combined_expression_file, delimiter='\t', fieldnames=fields, lineterminator="\n")
+        combined_tsv_writer.writeheader()
+
+        combined_filepath_json = combined_file_basepath + '.json'
+        with open(combined_filepath_json, 'w') as outfile:
+            json.dump(sum(associations.values(), []), outfile)
+
+        for taxon_id in associations:
+            taxon_file_basepath = os.path.join(self.generated_files_folder, file_basename + '.' + taxon_id)
+            taxon_filepath_json = taxon_file_basepath + '.json'
+            with open(taxon_filepath_json, 'w') as f:
+                json.dump(associations[taxon_id], f)
+
+        for taxon_id in associations:
+            for association in associations[taxon_id]:
+                for key in association:
+                    if isinstance(association[key], list):
+                        association[key] = ','.join(association[key])
+
+            combined_tsv_writer.writerows(associations[taxon_id])
+            taxon_filename_tsv = taxon_file_basepath + '.tsv'
+            with open(taxon_filename_tsv, 'w') as f:
+                f.write(self._generate_header(self.config_info, [taxon_id]))
+                tsv_writer = csv.DictWriter(f, delimiter='\t', fieldnames=fields, lineterminator="\n")
+                tsv_writer.writeheader()
+                tsv_writer.writerows(associations[taxon_id])
+
+        combined_expression_file.close()
+
         if upload_flag:
-            logger.info("Submitting to FMS")
+            logger.info("Submitting expression files to FMS")
             process_name = "1"
-            upload.upload_process(process_name, filename, self.generated_files_folder, 'EXPRESSION-ALLIANCE', 'COMBINED', self.config_info)
+            upload.upload_process(process_name, combined_filepath_tsv, self.generated_files_folder, 'EXPRESSION-ALLIANCE', 'COMBINED', self.config_info)
+            upload.upload_process(process_name, combined_filepath_json, self.generated_files_folder, 'EXPRESSION-ALLIANCE-JSON', 'COMBINED', self.config_info)
+            for taxon_id in associations:
+                for file_extension in ['json', 'tsv']:
+                    filename = file_basename + "." + taxon_id + '.' + file_extension
+                    datatype = "Expression-ALLIANCE"
+                    if file_extension is "json":
+                        datatype += "-JSON"
+                    upload.upload_process(process_name, filename, self.generated_files_folder, datatype, self.taxon_id_fms_subtype_map[taxon_id], self.config_info)


### PR DESCRIPTION
This code splits the results into taxon-specific files and submits them to the FMS. It now supports both JSON and TSV formats for the disease and expression file. 

I have looked through the results for disease and have them submitted to the FMS - they look correct. But have not been able to run the expression fully due to memory. 

@oblodgett This may cause memory issues when it is pulled in. The query to Neo4j itself is identical the only issue is the code for supporting both the JSON and TSV may be an issue memory-wise. When I test with filtered queries I do not have an issue but I am not able to run it fully.

@nuin at some point we should abstract out the logic for splitting files into species-specific files. There is code for these two filetypes that's very similar.  

I am out for today. If there are issues I will work on them, first thing in the morning. 