### PR TITLE
adding transcript level consequences AGR-2190

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -131,7 +131,8 @@ def generate_vcf_files(generated_files_folder, fasta_sequences_folder, skip_chro
                      WHERE NOT v.genomicReferenceSequence = v.genomicVariantSequence
                            OR v.genomicVariantSequence = ""
                      OPTIONAL MATCH (a:Allele)-[:IS_ALLELE_OF]-(g:Gene)
-                     OPTIONAL MATCH (v:Variant)-[:ASSOCIATION]-(m:GeneLevelConsequence)-[:ASSOCIATION]-(g:Gene)
+                     OPTIONAL MATCH (v:Variant)-[:ASSOCIATION]-(glc:GeneLevelConsequence)-[:ASSOCIATION]-(g:Gene)
+                     OPTIONAL MATCH (v:Variant)-[:ASSOCIATION]-(tlc:TranscriptLevelConsequence)-[:ASSOCIATION]-(t:Transcript)
                      RETURN c.primaryKey AS chromosome,
                             v.globalId AS globalId,
                             right(v.paddingLeft,1) AS paddingLeft,
@@ -145,8 +146,12 @@ def generate_vcf_files(generated_files_folder, fasta_sequences_folder, skip_chro
                             a.primaryKey AS alleles,
                             collect(DISTINCT {gene: g.primaryKey,
                                               geneSymbol: g.symbol,
-                                              consequence: m.geneLevelConsequence,
-                                              impact: m.impact}) AS geneConsequences,
+                                              consequence: glc.geneLevelConsequence,
+                                              impact: glc.impact}) AS geneConsequences,
+                            collect(DISTINCT {transcript: t.primaryKey,
+                                              transcriptGFF3ID: t.gff3ID,
+                                              consequence: tlc.transcriptLevelConsequence,
+                                              impact: tlc.impact}) AS transcriptConsequences,
                             p.start AS start,
                             p.end AS end,
                             s.name AS species,

--- a/src/generators/vcf_file_generator.py
+++ b/src/generators/vcf_file_generator.py
@@ -32,13 +32,18 @@ class VcfFileGenerator:
 ##ALT=<ID=H,Description="IUPAC code H = A/C/T">
 ##ALT=<ID=V,Description="IUPAC code V = A/C/G">
 ##INFO=<ID=hgvs_nomenclature,Number=1,Type=String,Description="the HGVS name of the allele">
-##INFO=<ID=geneLevelConsequence,Number=.,Type=String,Description="VEP consequence of the variant">
-##INFO=<ID=impact,Number=1,Type=String,Description="Variant impact scale">
-##INFO=<ID=symbol,Number=1,Type=String,Description="The human readable name of the allele">
+##INFO=<ID=geneLevelConsequence,Number=.,Type=String,Description="VEP consequence of the variant on the Gene">
+##INFO=<ID=transcriptLevelConsequence,Number=.,Type=String,Description="VEP consequence of the variant on the Transcript">
+##INFO=<ID=geneImpact,Number=1,Type=String,Description="Variant impact scale for Gene">
+##INFO=<ID=transcriptImpact,Number=1,Type=String,Description="Variant impact scale for Transcript">
+##INFO=<ID=alleleSymbol,Number=1,Type=String,Description="The human readable name of the Allele">
 ##INFO=<ID=soTerm,Number=1,Type=String,Description="The Sequence Ontology term for the variant">
 ##INFO=<ID=alleles,Number=.,Type=String,Description="The alleles of the variant">
 ##INFO=<ID=allele_of_gene_ids,Number=.,Type=String,Number=1,Description="The gene ids that the Allele is located on">
 ##INFO=<ID=allele_of_gene_symbols,Number=.,Type=String,Number=1,Description="The gene names that the Allele is located on">
+##INFO=<ID=allele_of_transcripts_ids,Number=.,Type=String,Number=1,Description="The gene ids that the Allele is located on">
+##INFO=<ID=allele_of_transcripts_gff3_ids,Number=.,Type=String,Number=1,Description="The transcript gff3ID that the Allele is located on">
+
 ##INFO=<ID=symbol_text,Number=1,Type=String,Description="Another human readable representation of the allele">
 ##phasing=partial
 ##source=AGR VCF File generator"""
@@ -92,39 +97,82 @@ class VcfFileGenerator:
         info_map['hgvs_nomenclature'] = cls._variant_value_for_file(variant, 'hgvsNomenclature')
 
         variant['geneLevelConsequence'] = []
-        variant['impact'] = []
+        variant['transcriptLevelConsequence'] = []
+        variant['geneImpact'] = []
+        variant['transcriptImpact'] = []
         variant['geneSymbols'] = []
+        variant['transcriptGFF3IDs'] = []
         variant['geneIDs'] = []
+        variant['transcriptIDs'] = []
         for geneConsequence in variant['geneConsequences']:
             if geneConsequence['consequence'] is not None:
                 variant['geneLevelConsequence'].append(geneConsequence['consequence'])
             else:
                 variant['geneLevelConsequence'].append('')
             if geneConsequence['impact'] is not None:
-                variant['impact'].append(geneConsequence['impact'])
+                variant['geneImpact'].append(geneConsequence['impact'])
             else:
-                variant['impact'].append('')
+                variant['geneImpact'].append('')
             if geneConsequence['gene'] is not None:
                   variant['geneIDs'].append(geneConsequence['gene'])
                   variant['geneSymbols'].append(geneConsequence['geneSymbol'])
             else:
                   variant['geneSymbols'].append('')
 
+        for transcriptConsequence in variant['transcriptConsequences']:
+            if transcriptConsequence['consequence'] is not None:
+                variant['transcriptLevelConsequence'].append(transcriptConsequence['consequence'])
+            else:
+                variant['transcriptLevelConsequence'].append('')
+            if transcriptConsequence['impact'] is not None:
+                variant['transcriptImpact'].append(transcriptConsequence['impact'])
+            else:
+                variant['transcriptImpact'].append('')
+            if transcriptConsequence['transcript'] is not None:
+                  variant['transcriptIDs'].append(transcriptConsequence['transcript'])
+                  if transcriptConsequence['transcriptGFF3ID']:
+                      variant['transcriptGFF3IDs'].append(transcriptConsequence['transcriptGFF3ID'])
+                  else:
+                      variant['transcriptGFF3IDs'].append('')
+            else:
+                  variant['transcriptGFF3IDs'].append('')
+
+
         if cls._variant_value_for_file(variant, 'geneLevelConsequence') is not None:
             info_map['geneLevelConsequence'] = ','.join(cls._variant_value_for_file(variant, 'geneLevelConsequence'))
         else:
             info_map['geneLevelConsequence'] = cls._variant_value_for_file(variant, 'geneLevelConsequence')
 
-        if cls._variant_value_for_file(variant, 'geneLevelConsequence') is not None:
-            info_map['impact'] = ','.join(cls._variant_value_for_file(variant, 'impact'))
+        if cls._variant_value_for_file(variant, 'transcriptLevelConsequence') is not None:
+            info_map['transcriptLevelConsequence'] = ','.join(cls._variant_value_for_file(variant, 'transcriptLevelConsequence'))
         else:
-            info_map['impact'] = cls._variant_value_for_file(variant, 'impact')
+            info_map['transcriptLevelConsequence'] = cls._variant_value_for_file(variant, 'transcriptLevelConsequence')
+
+
+        if cls._variant_value_for_file(variant, 'geneLevelConsequence') is not None:
+            info_map['geneImpact'] = ','.join(cls._variant_value_for_file(variant, 'geneImpact'))
+        else:
+            info_map['geneImpact'] = cls._variant_value_for_file(variant, 'geneImpact')
+
+
+        if cls._variant_value_for_file(variant, 'geneLevelConsequence') is not None:
+            info_map['transcriptImpact'] = ','.join(cls._variant_value_for_file(variant, 'transcriptImpact'))
+        else:
+            info_map['transcriptImpact'] = cls._variant_value_for_file(variant, 'transcriptImpact')
+
         info_map['symbol'] = cls._variant_value_for_file(variant, 'symbol')
         info_map['soTerm'] = cls._variant_value_for_file(variant, 'soTerm')
         info_map['globalId'] = variant['globalId']
         info_map['alleles'] = variant['alleles']#cls._variant_value_for_file(variant,'alleles',transform=','.join)
-        info_map['allele_of_gene_ids'] = cls._variant_value_for_file(variant, 'geneIDs', transform=','.join)
-        info_map['allele_of_gene_symbols'] = cls._variant_value_for_file(variant, 'geneSymbols', transform=','.join)
+
+        if variant['geneIDs']:
+             info_map['allele_of_gene_ids'] = cls._variant_value_for_file(variant, 'geneIDs', transform=','.join)
+             info_map['allele_of_gene_symbols'] = cls._variant_value_for_file(variant, 'geneSymbols', transform=','.join)
+
+        if variant['transcriptIDs']:
+            info_map['allele_of_transcript_ids'] = cls._variant_value_for_file(variant, 'transcriptIDs', transform=','.join)
+            info_map['allele_of_transcript_gff3_ids'] = cls._variant_value_for_file(variant, 'transcriptGFF3IDs', transform=','.join)
+
         info_map['symbol_text'] = cls._variant_value_for_file(variant, 'symbolText')
         if any(info_map.values()):
             info = ';'.join('{}="{}"'.format(k, v)


### PR DESCRIPTION
I have added the transcript level consequences in with pull request. 

Here is what a typical line looks like: 
```
GRCz11-3.1.0.vcf:1      267957  NC_007112.7:g.267957C>T C       T       .       .       hgvs_nomenclature="NC_007112.7:g.267957C>T";geneLevelConsequence="stop_gained";transcriptLevelConsequence="intron_variant,stop_gained,intron_variant,non_coding_transcript_variant";geneImpact="HIGH";transcriptImpact="MODIFIER,HIGH,MODIFIER";symbol="sa19390";soTerm="point_mutation";alleles="ZFIN:ZDB-ALT-161003-10664";allele_of_gene_ids="ZFIN:ZDB-GENE-060929-860";allele_of_gene_symbols="cenpe";allele_of_transcript_ids="ENSEMBL:ENSDART00000148172,ENSEMBL:ENSDART00000111806,ENSEMBL:ENSDART00000139438";allele_of_transcript_gff3_ids="ENSDART00000148172,ENSDART00000111806,ENSDART00000139438";symbol_text="sa19390"
```

@scottcain and @nathandunn In addition to the new fields in the INFO column the impact field has been changed into "geneImpact" and "transcriptImpact"

@nuin I didn't add this into the function for the tsv version of the VCF. I am not sure if it is necessary to maintain this code anymore. If it is we can add this in once we know this is what is needed downstream. 