### PR TITLE
fix(packaging): modified setup.py to include all subpackages and single modules required

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include agrfilegenerator/generators/*.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include agrfilegenerator/generators/*.txt
+include src/generators/*.txt

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -13,8 +13,9 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/alliance-genome/agr_file_generator",
     include_package_data=True,
-    package_dir={'agrfilegenerator': 'src'},
-    packages=['agrfilegenerator'],
+    package_dir={'': 'src'},
+    packages=find_packages('src'),
+    py_modules=['common', 'data_source'],
     install_requires=[
         'neo4j==1.7.3',
         'neobolt==1.7.13',

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,5 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.5',
 )

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
-from setuptools import setup, find_namespace_packages
+from setuptools import setup
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    name="agr_file_generator",
+    name="agrfilegenerator",
     version="3.1.0",
     author="Alliance of Genome Resources",
     author_email="valearna@caltech.edu",
@@ -13,8 +13,8 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/alliance-genome/agr_file_generator",
     include_package_data=True,
-    packages=find_namespace_packages(include=['.*']),
-    package_dir={'': 'src'},
+    package_dir={'agrfilegenerator': 'src'},
+    packages=['agrfilegenerator'],
     install_requires=[
         'neo4j==1.7.3',
         'neobolt==1.7.13',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,44 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="agr_file_generator",
+    version="3.1.0",
+    author="Alliance of Genome Resources",
+    author_email="valearna@caltech.edu",
+    description="This tool creates files from Alliance resources",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/alliance-genome/agr_file_generator",
+    package_dir={'': 'src'},
+    packages=["generators"],
+    install_requires=[
+        'neo4j==1.7.3',
+        'neobolt==1.7.13',
+        'neotime==1.7.4',
+        'python-dateutil==2.7.3',
+        'requests==2.21.0',
+        'Bio==0.1.0',
+        'wget==3.2',
+        'biopython==1.73',
+        'pyfaidx==0.5.5.2',
+        'wheel==0.33.4',
+        'pytest==4.6.2',
+        'Click==7.0',
+        'requests==2.21.0',
+        'requests-toolbelt==0.9.1',
+        'retry==0.9.2',
+        'urllib3==1.24.2',
+        'coloredlogs==10.0',
+        'PyYAML==5.1',
+        'json5==0.8.5'
+    ],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.6',
+)

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-import setuptools
+from setuptools import setup, find_packages
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-setuptools.setup(
+setup(
     name="agr_file_generator",
     version="3.1.0",
     author="Alliance of Genome Resources",
@@ -12,8 +12,9 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/alliance-genome/agr_file_generator",
+    include_package_data=True,
+    packages=find_packages('src'),
     package_dir={'': 'src'},
-    packages=["generators"],
     install_requires=[
         'neo4j==1.7.3',
         'neobolt==1.7.13',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    name="agrfilegenerator",
+    name="agr-file-generator",
     version="3.1.0",
     author="Alliance of Genome Resources",
     author_email="valearna@caltech.edu",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/alliance-genome/agr_file_generator",
     include_package_data=True,
-    packages=find_packages('src'),
+    packages=['generators', 'common', 'upload', 'data_source'],
     package_dir={'': 'src'},
     install_requires=[
         'neo4j==1.7.3',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -13,7 +13,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/alliance-genome/agr_file_generator",
     include_package_data=True,
-    packages=['generators', 'common', 'upload', 'data_source'],
+    packages=find_namespace_packages(include=['.*']),
     package_dir={'': 'src'},
     install_requires=[
         'neo4j==1.7.3',

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,0 @@
-from .generators.header import create_header

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+from .generators.header import create_header


### PR DESCRIPTION
This PR adds missing modules (in .py files not included in any subpackage) that are required to correctly install and import the packages.

If you can, please test the package installation process by running the following command:
$ pip3 install git+https://github.com/alliance-genome/agr_file_generator.git@46bd8e3

Which is pointing to the latest commit included in this PR

To test the library, run python3 and the following commands:
>> from generators.header import create_header
>> print(create_header(file_type='txt', database_version='3.1.0'))