### PR TITLE
Using a Ordered Dict for the species list in header.py

### DIFF
--- a/src/generators/daf_file_generator.py
+++ b/src/generators/daf_file_generator.py
@@ -15,6 +15,7 @@ import json
 import csv
 
 import upload
+from common import get_ordered_species_dict
 from .header import create_header
 
 logger = logging.getLogger(name=__name__)
@@ -39,7 +40,7 @@ class DafFileGenerator:
         self.generated_files_folder = generated_files_folder
 
     @classmethod
-    def _generate_header(cls, config_info, species):
+    def _generate_header(cls, config_info, taxon_ids):
         """
         TBA
 
@@ -50,19 +51,10 @@ class DafFileGenerator:
 
         stringency_filter = 'Stringent'
 
-        if len(species.keys()) == 1:
-            species_names = ''.join(list(species.values()))
-            taxon_ids = '# TaxonIDs: ' + ''.join(species.keys())
-        else:
-            taxon_ids = '# TaxonIDs: NCBITaxon:9606, NCBITaxon:10116, NCBITaxon:10090, NCBITaxon:7955, NCBITaxon:7227, NCBITaxon:6239, NCBITaxon:559292'
-            species_names = 'Homo sapiens, Rattus norvegicus, Mus musculus, Danio rerio, Drosophila melanogaster, Caenorhabditis elegans, Saccharomyces cerevisiae'
-
         return create_header('Disease', config_info.config['RELEASE_VERSION'],
-                             taxon_ids=taxon_ids,
-                             species=species_names,
+                             ordered_taxon_species_map=get_ordered_species_dict(config_info, taxon_ids),
                              data_format='tsv',
                              stringency_filter=stringency_filter)
-
 
     def generate_file(self, upload_flag=False):
         """

--- a/src/generators/expression_file_generator.py
+++ b/src/generators/expression_file_generator.py
@@ -12,6 +12,7 @@ import json
 import csv
 import upload
 from .header import create_header
+from common import get_ordered_species_dict
 
 logger = logging.getLogger(name=__name__)
 
@@ -35,7 +36,7 @@ class ExpressionFileGenerator:
         self.generated_files_folder = generated_files_folder
 
     @classmethod
-    def _generate_header(cls, config_info, species):
+    def _generate_header(cls, config_info, taxon_ids):
         """
 
         :param config_info:
@@ -43,16 +44,9 @@ class ExpressionFileGenerator:
         :return:
         """
 
-        if len(species.keys()) == 1:
-            species_names = ''.join(list(species.values()))
-            taxon_ids = '# TaxonIDs:' + ''.join(species.keys())
-        else:
-            taxon_ids = '# TaxonIDs: NCBITaxon:9606, NCBITaxon:10116, NCBITaxon:10090, NCBITaxon:7955, NCBITaxon:7227, NCBITaxon:6239, NCBITaxon:559292'
-            species_names = 'Homo sapiens, Rattus norvegicus, Mus musculus, Danio rerio, Drosophila melanogaster, Caenorhabditis elegans, Saccharomyces cerevisiae'
-
-        return create_header('Expression', config_info.config['RELEASE_VERSION'],
-                             taxon_ids=taxon_ids,
-                             species=species_names,
+        return create_header('Expression',
+                             config_info.config['RELEASE_VERSION'],
+                             ordered_taxon_species_map=get_ordered_species_dict(config_info, taxon_ids),
                              data_format='tsv')
 
     # 'StageID', currently don't have stage IDs in the database
@@ -165,7 +159,7 @@ class ExpressionFileGenerator:
 
         combined_filepath_tsv = combined_file_basepath + '.tsv'
         combined_expression_file = open(combined_filepath_tsv, 'w')
-        combined_expression_file.write(self._generate_header(self.config_info, species))
+        combined_expression_file.write(self._generate_header(self.config_info, species.keys()))
         combined_tsv_writer = csv.DictWriter(combined_expression_file, delimiter='\t', fieldnames=fields, lineterminator="\n")
         combined_tsv_writer.writeheader()
 

--- a/src/generators/header.py
+++ b/src/generators/header.py
@@ -8,7 +8,7 @@ class HeaderTemplate(Template):
     delimiter = '%'
 
 
-def create_header(file_type, database_version, data_format='', readme='', stringency_filter='', taxon_ids='', species=''):
+def create_header(file_type, database_version, data_format='', readme='', stringency_filter='', ordered_taxon_species_map=''):
     """
 
     :param file_type:
@@ -22,9 +22,14 @@ def create_header(file_type, database_version, data_format='', readme='', string
         stringency_filter = '\n# Orthology Filter: ' + stringency_filter
 
     gen_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M")
-    to_change = {'filetype': file_type, 'taxon_ids': taxon_ids, 'database_version': database_version,
-                 'gen_time': gen_time, 'stringency_filter': stringency_filter, 'data_format': data_format,
-                 'readme': readme, 'species': species}
+    to_change = {"filetype": file_type,
+                 "taxon_ids": ", ".join(ordered_taxon_species_map.keys()),
+                 "species":  ", ".join(ordered_taxon_species_map.values()),
+                 'database_version': database_version,
+                 'gen_time': gen_time,
+                 'stringency_filter': stringency_filter,
+                 'data_format': data_format,
+                 'readme': readme}
 
     my_path = os.path.abspath(os.path.dirname(__file__))
     file_header_template = HeaderTemplate(open(my_path + '/header_template.txt').read())

--- a/src/generators/header_template.txt
+++ b/src/generators/header_template.txt
@@ -6,7 +6,7 @@
 # Source: Alliance of Genome Resources (Alliance)
 # Source URL: http://alliancegenome.org/downloads
 # Help Desk: help@alliancegenome.org%stringency_filter
-%taxon_ids
+# Taxon IDs: %taxon_ids
 # Species: %species
 # Alliance Database Version: %database_version
 # Date file generated (UTC): %gen_time

--- a/src/generators/uniprot_cross_reference_generator.py
+++ b/src/generators/uniprot_cross_reference_generator.py
@@ -17,15 +17,10 @@ class UniProtGenerator:
 
     def _write_uniprot_file(cls, relationships, tab_file):
         logger.info('Writing output file')
-        output_file = open(cls.generated_files_folder + '/' + tab_file, 'w')
-        output_file.write(cls.file_header + '\n')
-        output_file.close()
-
-        with open(cls.generated_files_folder + '/' + tab_file, 'a') as tsvfile:
-            writer = csv.writer(tsvfile, delimiter='\t')
+        with open(cls.generated_files_folder + '/' + tab_file, 'w') as tsvfile:
+            tsvfile.write(cls.file_header + "\n")
             for item in relationships:
-                writer.writerow([item['GlobalCrossReferenceID'], item['GeneID']])
-        tsvfile.close()
+                tsvfile.write(item['GlobalCrossReferenceID'] + "\t" + item['GeneID'] + "\n")
 
     def generate_file(self, upload_flag=False):
         self._write_uniprot_file(self.relationships, 'CROSSREFERENCEUNIPROT_COMBINED.tsv')


### PR DESCRIPTION
This code does a query to the database to get the taxon IDs and species names into an OrderedDict. From there the species for the file are ordered and then sent to the header.py. 

This cleans up what is passed to header.py

I tested this by looking at the headers that were generated for orthology, disease, and expression. They looked right to me.

I am pulling into master as the header itself is not changing and this gives a chance for the file_generator and others to use the improvements. 

@valearna and @azurebrd you could use get_ordered_species_dict but you will have to create a config_info object to perform the query. I am not sure if you want to do this or not but it would be convenient for you to use the same function. Although it woudn't be too hard to just cut and past the query into your own code. 