### PR TITLE
Adding headers to JSON files AGR-2296

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ urllib3==1.24.2
 coloredlogs==10.0
 PyYAML==5.1
 json5==0.8.5
+jsonschema==3.2.0
+simplejson==3.17.0

--- a/schemas/disease.schema
+++ b/schemas/disease.schema
@@ -57,63 +57,75 @@
       "items": {
         "type": "object",
         "properties": {
-          "Gene1ID": {
+          "Taxon": {
             "type": "string"
           },
-          "Gene1Symbol": {
+          "SpeciesName": {
             "type": "string"
           },
-          "Gene1SpeciesTaxonID": {
+          "DBobjectType": {
             "type": "string"
           },
-          "Gene1SpeciesName": {
+          "DBObjectID": {
             "type": "string"
           },
-          "Gene2ID": {
+          "DBObjectSymbol": {
             "type": "string"
           },
-          "Gene2Symbol": {
+          "AssociationType": {
             "type": "string"
           },
-          "Gene2SpeciesTaxonID": {
+          "DOID": {
             "type": "string"
           },
-          "Gene2SpeciesName": {
+          "DOtermName": {
             "type": "string"
           },
-          "Algorithms": {
+          "WithOrthologs": {
             "type": "array",
             "items": {
               "type": "string"
             }
           },
-          "AlgorithmsMatch": {
+          "InferredFromID": {
             "type": "string"
           },
-          "OutOfAlgorithms": {
-            "type": "integer"
-          },
-          "IsBestScore": {
+          "InferredFromSymbol": {
             "type": "string"
           },
-          "IsBestRevScore": {
+          "EvidenceCode": {
+            "type": "string"
+          },
+          "EvidenceCodeName": {
+            "type": "string"
+          },
+          "Reference": {
+            "type": "string"
+          },
+          "Date": {
+            "type": "string"
+          },
+          "Source": {
             "type": "string"
           }
         },
         "required": [
-          "Algorithms",
-          "AlgorithmsMatch",
-          "Gene1ID",
-          "Gene1SpeciesName",
-          "Gene1SpeciesTaxonID",
-          "Gene1Symbol",
-          "Gene2ID",
-          "Gene2SpeciesName",
-          "Gene2SpeciesTaxonID",
-          "Gene2Symbol",
-          "IsBestRevScore",
-          "IsBestScore",
-          "OutOfAlgorithms"
+          "AssociationType",
+          "DBObjectID",
+          "DBObjectSymbol",
+          "DBobjectType",
+          "DOID",
+          "DOtermName",
+          "Date",
+          "EvidenceCode",
+          "EvidenceCodeName",
+          "InferredFromID",
+          "InferredFromSymbol",
+          "Reference",
+          "Source",
+          "SpeciesName",
+          "Taxon",
+          "WithOrthologs"
         ]
       }
     }

--- a/schemas/expression.schema
+++ b/schemas/expression.schema
@@ -1,0 +1,253 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "filetype": {
+          "type": "string"
+        },
+        "databaseVersion": {
+          "type": "string"
+        },
+        "genTime": {
+          "type": "string"
+        },
+        "stringencyFilter": {
+          "type": "string"
+        },
+        "dataFormat": {
+          "type": "string"
+        },
+        "readme": {
+          "type": "string"
+        },
+        "species": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "taxonId": {
+                "type": "string"
+              },
+              "speciesName": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "speciesName",
+              "taxonId"
+            ]
+          }
+        }
+      },
+      "required": [
+        "dataFormat",
+        "databaseVersion",
+        "filetype",
+        "genTime",
+        "readme",
+        "species",
+        "stringencyFilter"
+      ]
+    },
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Species": {
+            "type": "string"
+          },
+          "SpeciesID": {
+            "type": "string"
+          },
+          "GeneID": {
+            "type": "string"
+          },
+          "GeneSymbol": {
+            "type": "string"
+          },
+          "Location": {
+            "type": "string"
+          },
+          "StageTerm": {
+            "type": "string"
+          },
+          "AssayID": {
+            "type": "string"
+          },
+          "AssayTermName": {
+            "type": "string"
+          },
+          "CellularComponentID": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "CellularComponentTerm": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "CellularComponentQualifierIDs": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "CellularComponentQualifierTermNames": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "SubStructureID": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "SubStructureName": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "SubStructureQualifierIDs": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "SubStructureQualifierTermNames": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "AnatomyTermID": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "AnatomyTermName": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "AnatomyTermQualifierIDs": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "AnatomyTermQualifierTermNames": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "SourceURL": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "Source": {
+            "type": "string"
+          },
+          "Reference": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "AnatomyTermID",
+          "AnatomyTermName",
+          "AnatomyTermQualifierIDs",
+          "AnatomyTermQualifierTermNames",
+          "AssayID",
+          "AssayTermName",
+          "CellularComponentID",
+          "CellularComponentQualifierIDs",
+          "CellularComponentQualifierTermNames",
+          "CellularComponentTerm",
+          "GeneID",
+          "GeneSymbol",
+          "Location",
+          "Reference",
+          "Source",
+          "SourceURL",
+          "Species",
+          "SpeciesID",
+          "StageTerm",
+          "SubStructureID",
+          "SubStructureName",
+          "SubStructureQualifierIDs",
+          "SubStructureQualifierTermNames"
+        ]
+      }
+    }
+  },
+  "required": [
+    "data",
+    "metadata"
+  ]
+}

--- a/schemas/gene-cross-references.schema
+++ b/schemas/gene-cross-references.schema
@@ -57,63 +57,28 @@
       "items": {
         "type": "object",
         "properties": {
-          "Gene1ID": {
+          "GeneID": {
             "type": "string"
           },
-          "Gene1Symbol": {
+          "GlobalCrossReferenceID": {
             "type": "string"
           },
-          "Gene1SpeciesTaxonID": {
+          "CrossReferenceCompleteURL": {
             "type": "string"
           },
-          "Gene1SpeciesName": {
+          "ResourceDescriptorPage": {
             "type": "string"
           },
-          "Gene2ID": {
-            "type": "string"
-          },
-          "Gene2Symbol": {
-            "type": "string"
-          },
-          "Gene2SpeciesTaxonID": {
-            "type": "string"
-          },
-          "Gene2SpeciesName": {
-            "type": "string"
-          },
-          "Algorithms": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "AlgorithmsMatch": {
-            "type": "string"
-          },
-          "OutOfAlgorithms": {
-            "type": "integer"
-          },
-          "IsBestScore": {
-            "type": "string"
-          },
-          "IsBestRevScore": {
+          "TaxonID": {
             "type": "string"
           }
         },
         "required": [
-          "Algorithms",
-          "AlgorithmsMatch",
-          "Gene1ID",
-          "Gene1SpeciesName",
-          "Gene1SpeciesTaxonID",
-          "Gene1Symbol",
-          "Gene2ID",
-          "Gene2SpeciesName",
-          "Gene2SpeciesTaxonID",
-          "Gene2Symbol",
-          "IsBestRevScore",
-          "IsBestScore",
-          "OutOfAlgorithms"
+          "CrossReferenceCompleteURL",
+          "GeneID",
+          "GlobalCrossReferenceID",
+          "ResourceDescriptorPage",
+          "TaxonID"
         ]
       }
     }

--- a/src/app.py
+++ b/src/app.py
@@ -7,7 +7,7 @@ import coloredlogs
 from common import ContextInfo
 from common import get_neo_uri
 from data_source import DataSource
-from generators import (daf_file_generator, db_summary_file_generator,
+from generators import (disease_file_generator, db_summary_file_generator,
                         expression_file_generator,
                         gene_cross_reference_file_generator,
                         orthology_file_generator, vcf_file_generator,
@@ -88,7 +88,7 @@ def main(vcf,
         generate_orthology_file(generated_files_folder, config_info, upload)
     if disease is True or all_filetypes is True:
         click.echo('INFO:\tGenerating Disease files')
-        generate_daf_file(generated_files_folder, config_info, taxon_id_fms_subtype_map, upload)
+        generate_disease_file(generated_files_folder, config_info, taxon_id_fms_subtype_map, upload)
     if expression is True or all_filetypes is True:
         click.echo('INFO:\tGenerating Expression files')
         generate_expression_file(generated_files_folder, config_info, taxon_id_fms_subtype_map, upload)
@@ -229,8 +229,8 @@ def generate_orthology_file(generated_files_folder, config_info, upload_flag):
         logger.info("Time Elapsed: %s", time.strftime("%H:%M:%S", time.gmtime(end_time - start_time)))
 
 
-def generate_daf_file(generated_files_folder, config_info, taxon_id_fms_subtype_map, upload_flag):
-    daf_query = '''MATCH (disease:DOTerm)-[:ASSOCIATION]-(dej:Association:DiseaseEntityJoin)-[:ASSOCIATION]-(object)-[:FROM_SPECIES]-(species:Species)
+def generate_disease_file(generated_files_folder, config_info, taxon_id_fms_subtype_map, upload_flag):
+    disease_query = '''MATCH (disease:DOTerm)-[:ASSOCIATION]-(dej:Association:DiseaseEntityJoin)-[:ASSOCIATION]-(object)-[:FROM_SPECIES]-(species:Species)
                    WHERE (object:Gene OR object:Allele OR object:AffectedGenomicModel)
                          AND dej.joinType IN ["IS_MARKER_FOR", // need to remove when removed from database
                                               "IS_IMPLICATED_IN", // need to remove when removed from database
@@ -273,16 +273,16 @@ def generate_daf_file(generated_files_folder, config_info, taxon_id_fms_subtype_
 
     if config_info.config["DEBUG"]:
         logger.info("Disease Association Query: ")
-        logger.info(daf_query)
+        logger.info(disease_query)
         start_time = time.time()
         logger.info("Start time: %s", time.strftime("%H:%M:%S", time.gmtime(start_time)))
 
-    data_source = DataSource(get_neo_uri(config_info), daf_query)
-    daf = daf_file_generator.DafFileGenerator(data_source,
-                                              generated_files_folder,
-                                              config_info,
-                                              taxon_id_fms_subtype_map)
-    daf.generate_file(upload_flag=upload_flag)
+    data_source = DataSource(get_neo_uri(config_info), disease_query)
+    disease = disease_file_generator.DiseaseFileGenerator(data_source,
+                                                          generated_files_folder,
+                                                          config_info,
+                                                          taxon_id_fms_subtype_map)
+    disease.generate_file(upload_flag=upload_flag)
 
     if config_info.config["DEBUG"]:
         end_time = time.time()

--- a/src/generators/__init__.py
+++ b/src/generators/__init__.py
@@ -1,5 +1,5 @@
 from .vcf_file_generator import VcfFileGenerator
-from .daf_file_generator import DafFileGenerator
+from .disease_file_generator import DiseaseFileGenerator
 from .orthology_file_generator import OrthologyFileGenerator
 from .expression_file_generator import ExpressionFileGenerator
 from .db_summary_file_generator import DbSummaryFileGenerator

--- a/src/generators/gene_cross_reference_file_generator.py
+++ b/src/generators/gene_cross_reference_file_generator.py
@@ -34,7 +34,7 @@ class GeneCrossReferenceFileGenerator:
         self.generated_files_folder = generated_files_folder
 
     @classmethod
-    def _generate_header(cls, config_info, taxon_ids):
+    def _generate_header(cls, config_info, taxon_ids, data_format):
         """
 
         :param config_info:
@@ -43,6 +43,7 @@ class GeneCrossReferenceFileGenerator:
 
         return create_header('Gene Cross Reference',
                              config_info.config['RELEASE_VERSION'],
+                             data_format=data_format,
                              config_info=config_info,
                              taxon_ids=taxon_ids)
 
@@ -78,15 +79,16 @@ class GeneCrossReferenceFileGenerator:
             taxon_ids.add(data['TaxonID'])
             rows.append(row)
 
-        gene_cross_reference_file.write(self._generate_header(self.config_info, taxon_ids))
+        gene_cross_reference_file.write(self._generate_header(self.config_info, taxon_ids, 'tsv'))
         tsv_writer = csv.DictWriter(gene_cross_reference_file, delimiter='\t', fieldnames=columns, lineterminator="\n")
         tsv_writer.writeheader()
         tsv_writer.writerows(rows)
         gene_cross_reference_file.close()
 
         with open(output_filepath_json, 'w') as outfile:
-            json.dump(listofxrefs, outfile)
-        outfile.close()
+            contents = {'metadata': self._generate_header(self.config_info, taxon_ids, 'json'),
+                        'data': listofxrefs}
+            json.dump(contents, outfile)
 
         if upload_flag:
             logger.info("Submitting to FMS")

--- a/src/generators/header.py
+++ b/src/generators/header.py
@@ -4,19 +4,23 @@ from string import Template
 from common import get_ordered_species_dict
 from common import ordered_taxon_species_map_from_data_dictionary
 
+
 class HeaderTemplate(Template):
 
     delimiter = '%'
 
 
-def create_header(file_type, database_version, config_info='', data_format='', readme='', stringency_filter='', taxon_ids=''):
+def create_header(file_type, database_version, data_format, config_info='', readme='', stringency_filter='', taxon_ids=''):
     """
 
     :param file_type:
     :param database_version:
+    :param data_format:
     :param config_info: if not provide will pull species from YAML data dictionary file
+    :param readme:
     :param stringency_filter:
     :param taxon_ids:
+    :param file_type:
     :return:
     """
 
@@ -27,18 +31,28 @@ def create_header(file_type, database_version, config_info='', data_format='', r
         stringency_filter = '\n# Orthology Filter: ' + stringency_filter
 
     gen_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M")
-    to_change = {"filetype": file_type,
-                 "taxon_ids": ", ".join(ordered_taxon_species_map.keys()),
-                 "species":  ", ".join(ordered_taxon_species_map.values()),
-                 'database_version': database_version,
-                 'gen_time': gen_time,
-                 'stringency_filter': stringency_filter,
-                 'data_format': data_format,
-                 'readme': readme}
+    metadata = {'filetype': file_type,
+                'databaseVersion': database_version,
+                'genTime': gen_time,
+                'stringencyFilter': stringency_filter,
+                'dataFormat': data_format,
+                'readme': readme}
 
-    my_path = os.path.abspath(os.path.dirname(__file__))
-    file_header_template = HeaderTemplate(open(my_path + '/header_template.txt').read())
+    if data_format == 'json':
+        species = []
+        for key, value in ordered_taxon_species_map.items():
+            species.append({'taxonId': key,
+                            'speciesName': value})
+        metadata['species'] = species
 
-    file_header = file_header_template.substitute(to_change)
+        return metadata
+    elif data_format == 'tsv':
+        metadata['taxonIds'] = ', '.join(ordered_taxon_species_map.keys())
+        metadata['species'] = ', '.join(ordered_taxon_species_map.values())
 
-    return file_header
+        my_path = os.path.abspath(os.path.dirname(__file__))
+        file_header_template = HeaderTemplate(open(my_path + '/header_template.txt').read())
+
+        return file_header_template.substitute(metadata)
+    else:
+        raise ValueError("Wrong data_format: " + "' - must be set to 'json' or 'tsv'")

--- a/src/generators/header_template.txt
+++ b/src/generators/header_template.txt
@@ -1,14 +1,14 @@
 ##########################################################################
 #
 # Data type: %filetype
-# Data format: %data_format
+# Data format: %dataFormat
 # README: %readme
 # Source: Alliance of Genome Resources (Alliance)
 # Source URL: http://alliancegenome.org/downloads
-# Help Desk: help@alliancegenome.org%stringency_filter
-# Taxon IDs: %taxon_ids
+# Help Desk: help@alliancegenome.org%stringencyFilter
+# Taxon IDs: %taxonIds
 # Species: %species
-# Alliance Database Version: %database_version
-# Date file generated (UTC): %gen_time
+# Alliance Database Version: %databaseVersion
+# Date file generated (UTC): %genTime
 #
 ##########################################################################

--- a/src/generators/orthology_file_generator.py
+++ b/src/generators/orthology_file_generator.py
@@ -17,15 +17,13 @@ class OrthologyFileGenerator:
         self.generated_files_folder = generated_files_folder
 
     @classmethod
-    def _generate_header(cls, config_info, taxon_ids):
-
-        stringency_filter = 'Stringent'
+    def _generate_header(cls, config_info, taxon_ids, data_format):
 
         return create_header('Orthology', config_info.config['RELEASE_VERSION'],
-                             stringency_filter=stringency_filter,
+                             stringency_filter='Stringent',
                              config_info=config_info,
                              taxon_ids=taxon_ids,
-                             data_format='tsv')
+                             data_format=data_format)
 
     def generate_file(self, upload_flag=False):
 
@@ -67,7 +65,9 @@ class OrthologyFileGenerator:
         json_filename = file_basename + ".json"
         json_filepath = os.path.join(self.generated_files_folder, json_filename)
         with open(json_filepath, 'w') as outfile:
-            json.dump(processed_orthologs, outfile)
+            contents = {'metadata': self._generate_header(self.config_info, taxon_ids, 'json'),
+                        'data': processed_orthologs}
+            json.dump(contents, outfile)
 
         for processed_ortholog in processed_orthologs:
             processed_ortholog['Algorithms'] = "|".join(set(processed_ortholog['Algorithms']))
@@ -75,7 +75,7 @@ class OrthologyFileGenerator:
         tsv_filename = file_basename + ".tsv"
         tsv_filepath = os.path.join(self.generated_files_folder, tsv_filename)
         tsv_file = open(tsv_filepath, 'w')
-        tsv_file.write(self._generate_header(self.config_info, taxon_ids))
+        tsv_file.write(self._generate_header(self.config_info, taxon_ids, 'tsv'))
 
         tsv_writer = csv.DictWriter(tsv_file, delimiter='\t', fieldnames=fields, lineterminator="\n")
         tsv_writer.writeheader()

--- a/tests/orthology.py
+++ b/tests/orthology.py
@@ -1,6 +1,5 @@
 # Paulo Nuin March 2020
 
-import app
 from click.testing import CliRunner
 
 import sys
@@ -11,7 +10,8 @@ import jsonschema
 import simplejson as json
 import pytest
 
-sys.path.append('../src')
+sys.path.append('./src')
+import app
 
 JSON_FILES = '../json'
 OUTPUT_DIR = '../output'

--- a/tests/vcf.py
+++ b/tests/vcf.py
@@ -1,4 +1,3 @@
-import app
 from click.testing import CliRunner
 import logging
 import os
@@ -9,6 +8,7 @@ from operator import itemgetter
 from itertools import groupby
 
 sys.path.append('../src')
+import app
 
 logger = logging.getLogger(name=__package__)
 


### PR DESCRIPTION
In this pull request, headers have been added to the JSON files as well as more schema files have been generated using GenSON for the rest of the JSON files. With these files, a team should be assembled to get the json-schema files from the agr_schemas repo.  

The headers are being generated by header.py and can be used by other Python repos as well in a similar way to the headers for the TSV files. 

The schema for the headers should also be separated out into its own schema file once they are moved to there official location in the agr_schemas repo. 