### PR TITLE
Check FMS response and throw error after 5 attemps - fix

### DIFF
--- a/src/upload/upload.py
+++ b/src/upload/upload.py
@@ -22,9 +22,12 @@ def upload_file(worker, filename, save_path, upload_file_prefix, config_info):
         logger.debug('{}: Attempting upload of data file: {}'.format(worker, os.path.join(save_path, filename)))
         logger.debug('{}: Attempting upload with header: {}'.format(worker, headers))
         logger.info("{}: Uploading data to {}) ...".format(worker, config_info.config['FMS_API_URL'] + '/api/data/submit/'))
-
-        response = requests.post(config_info.config['FMS_API_URL'] + '/api/data/submit', files=file_to_upload, headers=headers)
-        logger.info(response.text)
+        try:
+            response = requests.post(config_info.config['FMS_API_URL'] + '/api/data/submit', files=file_to_upload, headers=headers)
+            logger.info(response.text)
+        except requests.exceptions.RequestException as e:
+            logger.error(e)
+            raise(e)
 
 
 @retry(tries=5, delay=5, logger=logger)

--- a/src/upload/upload.py
+++ b/src/upload/upload.py
@@ -22,9 +22,10 @@ def upload_file(worker, filename, save_path, upload_file_prefix, config_info):
         logger.debug('{}: Attempting upload of data file: {}'.format(worker, os.path.join(save_path, filename)))
         logger.debug('{}: Attempting upload with header: {}'.format(worker, headers))
         logger.info("{}: Uploading data to {}) ...".format(worker, config_info.config['FMS_API_URL'] + '/api/data/submit/'))
+        response = requests.post(config_info.config['FMS_API_URL'] + '/api/data/submit', files=file_to_upload, headers=headers)
+        logger.info(response.text)
         try:
-            response = requests.post(config_info.config['FMS_API_URL'] + '/api/data/submit', files=file_to_upload, headers=headers)
-            logger.info(response.text)
+            response.raise_for_status()
         except requests.exceptions.RequestException as e:
             raise(e)
 

--- a/src/upload/upload.py
+++ b/src/upload/upload.py
@@ -26,7 +26,6 @@ def upload_file(worker, filename, save_path, upload_file_prefix, config_info):
             response = requests.post(config_info.config['FMS_API_URL'] + '/api/data/submit', files=file_to_upload, headers=headers)
             logger.info(response.text)
         except requests.exceptions.RequestException as e:
-            logger.error(e)
             raise(e)
 
 


### PR DESCRIPTION
Yesterday we ran into an issue where the File Generator took way too long on stage but completed correctly according to GOCD. When looking at the log output it showed that there was truly an error uploading to FMS - no files were uploaded. This change makes it so that we will raise an error and the File Generator will report this to GOCD by exiting the process with a non zero exit code. 

I tested this by making the FMS URL incorrect. 