### PR TITLE
Adding file validation before file upload AGR-2318

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /usr/src/app
 ADD requirements.txt .
 
 RUN pip3 install -r requirements.txt
+RUN apt install vcftools
 
 RUN mkdir tmp
 

--- a/src/common.py
+++ b/src/common.py
@@ -33,8 +33,7 @@ class ContextInfo(object):
         logger.debug('Initialized with config values: {}'.format(self.config))
 
 
-def compress(cmd):
-
+def run_command(cmd):
     logger.info('Running ' + cmd)
     process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     process.wait()

--- a/src/generators/db_summary_file_generator.py
+++ b/src/generators/db_summary_file_generator.py
@@ -88,7 +88,7 @@ class DbSummaryFileGenerator:
 
         return overview
 
-    def generate_file(self, upload_flag=False):
+    def generate_file(self, upload_flag=False, validate_flag=False):
         """
 
         :param upload_flag:
@@ -99,16 +99,17 @@ class DbSummaryFileGenerator:
 
         filename = 'db-summary-' + self.config_info.config['RELEASE_VERSION'] + '.json'
         filepath = os.path.join(self.generated_files_folder, filename)
-        print(filepath)
+        logger.info(filepath)
         with open(filepath, 'w') as json_file:
             json.dump(summary, json_file, sort_keys=True, indent=4)
 
-        if upload_flag:
-            logger.info("Submitting to FMS")
-            process_name = "1"
-            upload.upload_process(process_name,
-                                  filename,
-                                  self.generated_files_folder,
-                                  'DB-SUMMARY',
-                                  self.config_info.config['RELEASE_VERSION'],
-                                  self.config_info)
+        if validate_flag:
+            if upload_flag:
+                logger.info("Submitting to FMS")
+                process_name = "1"
+                upload.upload_process(process_name,
+                                      filename,
+                                      self.generated_files_folder,
+                                      'DB-SUMMARY',
+                                      self.config_info.config['RELEASE_VERSION'],
+                                      self.config_info)

--- a/src/generators/disease_file_generator.py
+++ b/src/generators/disease_file_generator.py
@@ -16,6 +16,7 @@ import csv
 
 import upload
 from .header import create_header
+from validators import json_validator
 
 logger = logging.getLogger(name=__name__)
 
@@ -227,17 +228,20 @@ class DiseaseFileGenerator:
         combined_disease_file.close()
 
         if validate_flag:
+            json_validator.JsonValidator(combined_filepath_json, 'disease').validateJSON()
             if upload_flag:
                 logger.info("Submitting disease files to FMS")
                 process_name = "1"
                 upload.upload_process(process_name, combined_filepath_tsv, self.generated_files_folder, 'DISEASE-ALLIANCE', 'COMBINED', self.config_info)
                 upload.upload_process(process_name, combined_filepath_json, self.generated_files_folder, 'DISEASE-ALLIANCE-JSON', 'COMBINED', self.config_info)
-                for taxon_id in processed_disease_associations:
-                    for file_extension in ['json', 'tsv']:
-                        filename = file_basename + "." + taxon_id + '.' + file_extension
-                        datatype = "DISEASE-ALLIANCE"
-                        if file_extension == "json":
-                            datatype += "-JSON"
+            for taxon_id in processed_disease_associations:
+                for file_extension in ['json', 'tsv']:
+                    filename = file_basename + "." + taxon_id + '.' + file_extension
+                    datatype = "DISEASE-ALLIANCE"
+                    if file_extension == "json":
+                        datatype += "-JSON"
+                        json_validator.JsonValidator(os.path.join(self.generated_files_folder, filename), 'disease').validateJSON()
+                    if upload_flag:
                         upload.upload_process(process_name,
                                               filename,
                                               self.generated_files_folder,

--- a/src/generators/disease_file_generator.py
+++ b/src/generators/disease_file_generator.py
@@ -54,7 +54,7 @@ class DiseaseFileGenerator:
                              data_format=data_format,
                              stringency_filter='Stringent')
 
-    def generate_file(self, upload_flag=False):
+    def generate_file(self, upload_flag=False, validate_flag=False):
         """
 
         :param upload_flag:
@@ -226,20 +226,21 @@ class DiseaseFileGenerator:
 
         combined_disease_file.close()
 
-        if upload_flag:
-            logger.info("Submitting disease files to FMS")
-            process_name = "1"
-            upload.upload_process(process_name, combined_filepath_tsv, self.generated_files_folder, 'DISEASE-ALLIANCE', 'COMBINED', self.config_info)
-            upload.upload_process(process_name, combined_filepath_json, self.generated_files_folder, 'DISEASE-ALLIANCE-JSON', 'COMBINED', self.config_info)
-            for taxon_id in processed_disease_associations:
-                for file_extension in ['json', 'tsv']:
-                    filename = file_basename + "." + taxon_id + '.' + file_extension
-                    datatype = "DISEASE-ALLIANCE"
-                    if file_extension == "json":
-                        datatype += "-JSON"
-                    upload.upload_process(process_name,
-                                          filename,
-                                          self.generated_files_folder,
-                                          datatype,
-                                          self.taxon_id_fms_subtype_map[taxon_id],
-                                          self.config_info)
+        if validate_flag:
+            if upload_flag:
+                logger.info("Submitting disease files to FMS")
+                process_name = "1"
+                upload.upload_process(process_name, combined_filepath_tsv, self.generated_files_folder, 'DISEASE-ALLIANCE', 'COMBINED', self.config_info)
+                upload.upload_process(process_name, combined_filepath_json, self.generated_files_folder, 'DISEASE-ALLIANCE-JSON', 'COMBINED', self.config_info)
+                for taxon_id in processed_disease_associations:
+                    for file_extension in ['json', 'tsv']:
+                        filename = file_basename + "." + taxon_id + '.' + file_extension
+                        datatype = "DISEASE-ALLIANCE"
+                        if file_extension == "json":
+                            datatype += "-JSON"
+                        upload.upload_process(process_name,
+                                              filename,
+                                              self.generated_files_folder,
+                                              datatype,
+                                              self.taxon_id_fms_subtype_map[taxon_id],
+                                              self.config_info)

--- a/src/generators/expression_file_generator.py
+++ b/src/generators/expression_file_generator.py
@@ -12,6 +12,8 @@ import json
 import csv
 import upload
 from .header import create_header
+from validators import json_validator
+
 
 logger = logging.getLogger(name=__name__)
 
@@ -194,20 +196,24 @@ class ExpressionFileGenerator:
         combined_expression_file.close()
 
         if validate_flag:
+            json_validator.JsonValidator(combined_filepath_json, 'expression').validateJSON()
+            process_name = "1"
             if upload_flag:
                 logger.info("Submitting expression files to FMS")
-                process_name = "1"
+
                 upload.upload_process(process_name, combined_filepath_tsv, self.generated_files_folder, 'EXPRESSION-ALLIANCE', 'COMBINED', self.config_info)
                 upload.upload_process(process_name, combined_filepath_json, self.generated_files_folder, 'EXPRESSION-ALLIANCE-JSON', 'COMBINED', self.config_info)
-                for taxon_id in associations:
-                    for file_extension in ['json', 'tsv']:
-                        filename = file_basename + "." + taxon_id + '.' + file_extension
-                        datatype = "EXPRESSION-ALLIANCE"
-                        if file_extension == "json":
-                            datatype += "-JSON"
-                        upload.upload_process(process_name,
-                                              filename,
-                                              self.generated_files_folder,
-                                              datatype,
-                                              self.taxon_id_fms_subtype_map[taxon_id],
-                                              self.config_info)
+            for taxon_id in associations:
+                for file_extension in ['json', 'tsv']:
+                    filename = file_basename + "." + taxon_id + '.' + file_extension
+                    datatype = "EXPRESSION-ALLIANCE"
+                    if file_extension == "json":
+                        datatype += "-JSON"
+                        json_validator.JsonValidator(os.path.join(self.generated_files_folder, filename), 'expression').validateJSON()
+                        if upload_flag:
+                            upload.upload_process(process_name,
+                                                  filename,
+                                                  self.generated_files_folder,
+                                                  datatype,
+                                                  self.taxon_id_fms_subtype_map[taxon_id],
+                                                  self.config_info)

--- a/src/generators/expression_file_generator.py
+++ b/src/generators/expression_file_generator.py
@@ -50,7 +50,7 @@ class ExpressionFileGenerator:
                              data_format=data_format)
 
     # 'StageID', currently don't have stage IDs in the database
-    def generate_file(self, upload_flag=False):
+    def generate_file(self, upload_flag=False, validate_flag=False):
         """
 
         :param upload_flag:
@@ -193,20 +193,21 @@ class ExpressionFileGenerator:
 
         combined_expression_file.close()
 
-        if upload_flag:
-            logger.info("Submitting expression files to FMS")
-            process_name = "1"
-            upload.upload_process(process_name, combined_filepath_tsv, self.generated_files_folder, 'EXPRESSION-ALLIANCE', 'COMBINED', self.config_info)
-            upload.upload_process(process_name, combined_filepath_json, self.generated_files_folder, 'EXPRESSION-ALLIANCE-JSON', 'COMBINED', self.config_info)
-            for taxon_id in associations:
-                for file_extension in ['json', 'tsv']:
-                    filename = file_basename + "." + taxon_id + '.' + file_extension
-                    datatype = "EXPRESSION-ALLIANCE"
-                    if file_extension == "json":
-                        datatype += "-JSON"
-                    upload.upload_process(process_name,
-                                          filename,
-                                          self.generated_files_folder,
-                                          datatype,
-                                          self.taxon_id_fms_subtype_map[taxon_id],
-                                          self.config_info)
+        if validate_flag:
+            if upload_flag:
+                logger.info("Submitting expression files to FMS")
+                process_name = "1"
+                upload.upload_process(process_name, combined_filepath_tsv, self.generated_files_folder, 'EXPRESSION-ALLIANCE', 'COMBINED', self.config_info)
+                upload.upload_process(process_name, combined_filepath_json, self.generated_files_folder, 'EXPRESSION-ALLIANCE-JSON', 'COMBINED', self.config_info)
+                for taxon_id in associations:
+                    for file_extension in ['json', 'tsv']:
+                        filename = file_basename + "." + taxon_id + '.' + file_extension
+                        datatype = "EXPRESSION-ALLIANCE"
+                        if file_extension == "json":
+                            datatype += "-JSON"
+                        upload.upload_process(process_name,
+                                              filename,
+                                              self.generated_files_folder,
+                                              datatype,
+                                              self.taxon_id_fms_subtype_map[taxon_id],
+                                              self.config_info)

--- a/src/generators/gene_cross_reference_file_generator.py
+++ b/src/generators/gene_cross_reference_file_generator.py
@@ -47,7 +47,7 @@ class GeneCrossReferenceFileGenerator:
                              config_info=config_info,
                              taxon_ids=taxon_ids)
 
-    def generate_file(self, upload_flag=False):
+    def generate_file(self, upload_flag=False, validate_flag=False):
         """
 
         :param upload_flag:
@@ -90,12 +90,13 @@ class GeneCrossReferenceFileGenerator:
                         'data': listofxrefs}
             json.dump(contents, outfile)
 
-        if upload_flag:
-            logger.info("Submitting to FMS")
-            process_name = "1"
-            logger.info("uploading TSV version of the gene cross references file.")
-            upload.upload_process(process_name, TSVfilename, self.generated_files_folder, 'GENECROSSREFERENCE',
-                                  'COMBINED', self.config_info)
-            logger.info("uploading JSON version of the gene cross references file.")
-            upload.upload_process(process_name, JSONfilename, self.generated_files_folder, 'GENECROSSREFERENCEJSON',
-                                  'COMBINED', self.config_info)
+        if validate_flag:
+            if upload_flag:
+                logger.info("Submitting to FMS")
+                process_name = "1"
+                logger.info("uploading TSV version of the gene cross references file.")
+                upload.upload_process(process_name, TSVfilename, self.generated_files_folder, 'GENECROSSREFERENCE',
+                                      'COMBINED', self.config_info)
+                logger.info("uploading JSON version of the gene cross references file.")
+                upload.upload_process(process_name, JSONfilename, self.generated_files_folder, 'GENECROSSREFERENCEJSON',
+                                      'COMBINED', self.config_info)

--- a/src/generators/gene_cross_reference_file_generator.py
+++ b/src/generators/gene_cross_reference_file_generator.py
@@ -13,6 +13,7 @@ import json
 
 from upload import upload
 from .header import create_header
+from validators import json_validator
 
 logger = logging.getLogger(name=__name__)
 
@@ -91,6 +92,7 @@ class GeneCrossReferenceFileGenerator:
             json.dump(contents, outfile)
 
         if validate_flag:
+            json_validator.JsonValidator(output_filepath_json, 'gene-cross-references').validateJSON()
             if upload_flag:
                 logger.info("Submitting to FMS")
                 process_name = "1"

--- a/src/generators/orthology_file_generator.py
+++ b/src/generators/orthology_file_generator.py
@@ -25,7 +25,7 @@ class OrthologyFileGenerator:
                              taxon_ids=taxon_ids,
                              data_format=data_format)
 
-    def generate_file(self, upload_flag=False):
+    def generate_file(self, upload_flag=False, validate_flag=False):
 
         file_basename = "agr_orthologs-" + self.config_info.config['RELEASE_VERSION']
         fields = ["Gene1ID",
@@ -82,8 +82,9 @@ class OrthologyFileGenerator:
         tsv_writer.writerows(processed_orthologs)
         tsv_file.close()
 
-        if upload_flag:
-            logger.info("Submitting orthology filse to FMS")
-            process_name = "1"
-            upload.upload_process(process_name, json_filepath, self.generated_files_folder, 'ORTHOLOGY-ALLIANCE-JSON', 'COMBINED', self.config_info)
-            upload.upload_process(process_name, tsv_filepath, self.generated_files_folder, 'ORTHOLOGY-ALLIANCE', 'COMBINED', self.config_info)
+        if validate_flag:
+            if upload_flag:
+                logger.info("Submitting orthology filse to FMS")
+                process_name = "1"
+                upload.upload_process(process_name, json_filepath, self.generated_files_folder, 'ORTHOLOGY-ALLIANCE-JSON', 'COMBINED', self.config_info)
+                upload.upload_process(process_name, tsv_filepath, self.generated_files_folder, 'ORTHOLOGY-ALLIANCE', 'COMBINED', self.config_info)

--- a/src/generators/orthology_file_generator.py
+++ b/src/generators/orthology_file_generator.py
@@ -5,6 +5,7 @@ import csv
 
 import upload
 from .header import create_header
+from validators import json_validator
 
 logger = logging.getLogger(name=__name__)
 
@@ -83,6 +84,7 @@ class OrthologyFileGenerator:
         tsv_file.close()
 
         if validate_flag:
+            json_validator.JsonValidator(json_filepath, 'orthology').validateJSON()
             if upload_flag:
                 logger.info("Submitting orthology filse to FMS")
                 process_name = "1"

--- a/src/generators/uniprot_cross_reference_generator.py
+++ b/src/generators/uniprot_cross_reference_generator.py
@@ -22,15 +22,16 @@ class UniProtGenerator:
             for item in relationships:
                 tsvfile.write(item['GlobalCrossReferenceID'] + "\t" + item['GeneID'] + "\n")
 
-    def generate_file(self, upload_flag=False):
+    def generate_file(self, upload_flag=False, validate_flag=False):
         self._write_uniprot_file(self.relationships, 'CROSSREFERENCEUNIPROT_COMBINED.tsv')
         logger.info('File created')
-        if upload_flag:
-            logger.info("Submitting CROSSREFERENCEUNIPROT_COMBINED to FMS")
-            process_name = "1"
-            upload.upload_process(process_name,
-                                  'CROSSREFERENCEUNIPROT_COMBINED.tsv',
-                                  self.generated_files_folder,
-                                  'CROSSREFERENCEUNIPROT',
-                                  'COMBINED',
-                                  self.config_info)
+        if validate_flag:
+            if upload_flag:
+                logger.info("Submitting CROSSREFERENCEUNIPROT_COMBINED to FMS")
+                process_name = "1"
+                upload.upload_process(process_name,
+                                      'CROSSREFERENCEUNIPROT_COMBINED.tsv',
+                                      self.generated_files_folder,
+                                      'CROSSREFERENCEUNIPROT',
+                                      'COMBINED',
+                                      self.config_info)

--- a/src/generators/vcf_file_generator.py
+++ b/src/generators/vcf_file_generator.py
@@ -4,7 +4,8 @@ import sys
 from collections import defaultdict, OrderedDict
 from functools import partial
 from operator import itemgetter
-from common import compress
+from common import run_command
+from validators import vcf_validator
 import logging
 import upload
 
@@ -237,7 +238,7 @@ class VcfFileGenerator:
             return None
         return variant
 
-    def generate_files(self, skip_chromosomes=(), upload_flag=False):
+    def generate_files(self, skip_chromosomes=(), upload_flag=False, validate_flag=False):
         (assembly_chr_variants, assembly_species) = self._consume_data_source()
         for (assembly, chromo_variants) in assembly_chr_variants.items():
             filename = assembly + '-' + self.config_info.config['RELEASE_VERSION'] + '.vcf'
@@ -255,13 +256,25 @@ class VcfFileGenerator:
                     adjusted_variants = filter(None, map(adjust_varient, variants))
                     for variant in sorted(adjusted_variants, key=itemgetter('POS')):
                         self._add_variant_to_vcf_file(vcf_file, variant)
-            stdout, stderr, return_code = compress('bgzip -c ' + filepath + ' > ' + filepath + '.gz')
+            stdout, stderr, return_code = run_command('bgzip -c ' + filepath + ' > ' + filepath + '.gz')
             if return_code == 0:
                 logger.info(filepath + ' compressed successfully')
             else:
                 logger.error(filepath + ' could not be compressed, please check')
-            if upload_flag:
-                logger.info("Submitting to FMS")
+
+            if validate_flag:
                 process_name = "1"
-                upload.upload_process(process_name, filename, self.generated_files_folder, 'VCF', assembly, self.config_info)
-                upload.upload_process(process_name, filename + ".gz", self.generated_files_folder, 'VCF-GZ', assembly, self.config_info)
+                filepath = os.path.join(self.generated_files_folder, filename)
+                stdout, stderr, return_code = run_command('vcf-validator ' + filepath)
+                logger.info(stdout)
+                logger.info(stderr.decode("utf-8"))
+                if return_code != 0:
+                    logger.error("vcf_validate caught error in file")
+                    exit(-1)
+
+                validator = vcf_validator.VcfValidator(filepath)
+                validator.validate_vcf()
+                if upload_flag:
+                    logger.info("Submitting to FMS")
+                    upload.upload_process(process_name, filename, self.generated_files_folder, 'VCF', assembly, self.config_info)
+                    upload.upload_process(process_name, filename + ".gz", self.generated_files_folder, 'VCF-GZ', assembly, self.config_info)

--- a/src/generators/vcf_file_generator.py
+++ b/src/generators/vcf_file_generator.py
@@ -265,13 +265,6 @@ class VcfFileGenerator:
             if validate_flag:
                 process_name = "1"
                 filepath = os.path.join(self.generated_files_folder, filename)
-                stdout, stderr, return_code = run_command('vcf-validator ' + filepath)
-                logger.info(stdout)
-                logger.info(stderr.decode("utf-8"))
-                if return_code != 0:
-                    logger.error("vcf_validate caught error in file")
-                    exit(-1)
-
                 validator = vcf_validator.VcfValidator(filepath)
                 validator.validate_vcf()
                 if upload_flag:

--- a/src/generators/vcf_header_template.txt
+++ b/src/generators/vcf_header_template.txt
@@ -14,14 +14,14 @@
 ##INFO=<ID=hgvs_nomenclature,Number=1,Type=String,Description="the HGVS name of the allele">
 ##INFO=<ID=geneLevelConsequence,Number=.,Type=String,Description="VEP consequence of the variant on the Gene">
 ##INFO=<ID=transcriptLevelConsequence,Number=.,Type=String,Description="VEP consequence of the variant on the Transcript">
-##INFO=<ID=geneImpact,Number=1,Type=String,Description="Variant impact scale for Gene">
+##INFO=<ID=geneImpact,Number=.,Type=String,Description="Variant impact scale for Gene">
 ##INFO=<ID=transcriptImpact,Number=.,Type=String,Description="Variant impact scale for Transcript">
 ##INFO=<ID=allele_ids,Number=.,Type=String,Description="The ID of the Allele">
 ##INFO=<ID=allele_symbols,Number=.,Type=String,Description="The human readable name of the Allele">
 ##INFO=<ID=allele_symbols_text,Number=.,Type=String,Description="Another human readable representation of the allele">
 ##INFO=<ID=soTerm,Number=1,Type=String,Description="The Sequence Ontology term for the variant">
-##INFO=<ID=allele_of_gene_ids,Number=1,Type=String,Description="The gene ids that the Allele is located on">
-##INFO=<ID=allele_of_gene_symbols,Number=1,Type=String,Description="The gene names that the Allele is located on">
+##INFO=<ID=allele_of_gene_ids,Number=.,Type=String,Description="The gene ids that the Allele is located on">
+##INFO=<ID=allele_of_gene_symbols,Number=.,Type=String,Description="The gene names that the Allele is located on">
 ##INFO=<ID=allele_of_transcript_ids,Number=.,Type=String,Description="The gene ids that the Allele is located on">
 ##INFO=<ID=allele_of_transcript_gff3_ids,Number=.,Type=String,Description="The transcript gff3ID that the Allele is located on">
 ##INFO=<ID=allele_of_transcript_gff3_names,Number=.,Type=String,Description="The transcript gff3 Names that the Allele is located on">

--- a/src/validators/__init__.py
+++ b/src/validators/__init__.py
@@ -1,0 +1,1 @@
+from .vcf_validator import VcfValidator

--- a/src/validators/__init__.py
+++ b/src/validators/__init__.py
@@ -1,1 +1,2 @@
 from .vcf_validator import VcfValidator
+from .json_validator import JsonValidator

--- a/src/validators/json_validator.py
+++ b/src/validators/json_validator.py
@@ -1,0 +1,35 @@
+import os
+import logging
+import json
+
+from jsonschema import validate
+from jsonschema import ValidationError
+from jsonschema import SchemaError
+
+logger = logging.getLogger(name=__name__)
+
+
+class JsonValidator:
+    def __init__(self, filepath, schema):
+        self.filepath = filepath
+        self.schema = schema
+
+    def validateJSON(self):
+        logger.info("validating " + self.filepath)
+        with open(self.filepath, "r") as jsonFile:
+            schema_filepath = os.path.join("./schemas/", self.schema) + '.schema'
+            with open(schema_filepath, "r") as schemaFile:
+                try:
+                    validate(json.load(jsonFile), json.load(schemaFile))
+                    logger.info("successfully validated against '%s'" % schema_filepath)
+                except SchemaError as e:
+                    logger.error(e)
+                    logger.error("There is an error with the schema")
+                    exit(-1)
+                except ValidationError as e:
+                    logger.error(e)
+                    logger.error("---------")
+                    logger.error(e.absolute_path)
+                    logger.error("---------")
+                    logger.error(e.absolute_schema_path)
+                    exit(-1)

--- a/src/validators/vcf_validator.py
+++ b/src/validators/vcf_validator.py
@@ -1,0 +1,113 @@
+import ntpath
+import logging
+import collections
+from operator import itemgetter
+from collections import OrderedDict
+from itertools import groupby
+
+
+logger = logging.getLogger(name=__name__)
+
+
+EXAMPLE_CASES = {
+  'GRCm38': [{'CHROMO': '13',
+              'POS': '50540171',
+              'ID': 'ZFIN:ZDB-ALT-160601-8105',
+              'REF': 'C',
+              'ALT': 'T',
+              'QUAL': '',
+              'FILTER': '',
+              'INFO': ''},
+             {'CHROMO': '5',
+              'POS': '72118556',
+              'ID': 'ZFIN:ZDB-ALT-170321-11',
+              'REF': 'CGCTTTGA',
+              'ALT': 'C',
+              'QUAL': '',
+              'FILTER': ''},
+             {'CHROM': '10',
+              'POS': '16027812',
+              'ID': 'ZFIN:ZDB-ALT-180207-16',
+              'REF': 'G',
+              'ALT': 'GCCGTT',
+              'QUAL': '',
+              'FILTER': '',
+              'INFO': ''}]}
+
+
+class VcfValidator:
+
+    def __init__(self, filepath):
+        self.filepath = filepath
+        self.filename = ntpath.basename(filepath)
+        self.assembly = self.filename.split('-')[0]
+
+    def parse_vcf_file(self, path):
+        """
+
+        :param path:
+        :return:
+        """
+
+        data = []
+        headers = []
+        with open(path, 'rt') as fp:
+            for line in fp:
+                if line.startswith('##'):
+                    continue
+                if line.startswith('#'):
+                    cols = line[1:].split('\t')
+                    headers.extend(cols)
+                    continue
+                else:
+                    cols = line.split('\t')
+                data.append(OrderedDict(zip(headers, cols)))
+        return data
+
+    def check_examples(self, parsed_vcf):
+        examples = EXAMPLE_CASES.get(self.assembly)
+        if not examples:
+            logger.info('No examples for ' + self.filename + ', skipping ...')
+        else:
+            for example in examples:
+                vcf_record = parsed_vcf.get(examples['ID'])
+                if vcf_record not in examples['ID']:
+                    logger.error('No matching VCF data found for example with id: ' + examples['ID'])
+                    exit(-1)
+                if vcf_record != example:
+                    logger.error('Mismatch between example and parsed VCF record')
+
+    def check_sorted_by_chromosome_and_position(self, parsed_vcf):
+        select_chromosome = itemgetter('CHROM')
+        chromosomes = list(map(select_chromosome, parsed_vcf))
+        assert chromosomes == sorted(chromosomes), 'Chromosomes not alphabetically sorted'
+        for (chromo, recs) in groupby(parsed_vcf, select_chromosome):
+            row = list(recs)
+            positions = list(int(col['POS']) for col in row)
+            if positions != sorted(positions):
+                logger.error('Positions are not sorted in correct order')
+                exit(-1)
+
+        logger.info('Sorted by chromosome and position')
+
+    def check_duplicate_entries(self, parsed_vcf):
+        all_entries = []
+        for variant in parsed_vcf:
+            all_entries.append(variant['ID'])
+
+        print(all_entries)
+        if len(all_entries) == len(set(all_entries)):
+            logger.info("No duplicate enteries")
+        else:
+            logger.error("At least one Duplicate entery")
+            logger.error([item for item, count in collections.Counter(all_entries).items() if count > 1])
+            exit(-1)
+
+    def validate_vcf(self):
+        logger.info("Validating VCF: %s" % self.filename)
+
+        parsed_vcf = self.parse_vcf_file(self.filepath)
+
+        self.check_examples(parsed_vcf)
+        self.check_sorted_by_chromosome_and_position(parsed_vcf)
+        self.check_duplicate_entries(parsed_vcf)


### PR DESCRIPTION
I am taking logic from the tests and moving them into logic for validating files. One of the benefits of this is we will be able to make tests for the validating of the files. 

Whenever the user specifies '--upload' the file will be validated before the upload. The user can also specify '--validate' without the upload if they want to validate locally. 

For VCF files we are also using the vcf_validataor tool in the VCFtools Ubuntu package. @oblodgett I am installing the ubuntu package in this repo's Dockerfile. If you want it to be installed in the base image for this Dockerfile, feel free to add it, and 
I will remove the line that adds it to this Dockerfile. 

I have also added validation for the JSON files that are generated. 

The schemas files we are using are currently in this repo. @sierra-moxon after this pull request, we can start talking about moving them to the agr_schemas repo. Hopefully, we get a chance to talk about the next steps sometime soon. 

The header part of the schema will need to be pulled out between the different schema files as it is supposed to follow the same schema for every file. @valearna @azurebrd I have made a generic validation function for validating each of the JSON files. All you have to provide is the filepath to the datafiles and have the schema file in the schemas folder. You might need us to move this to the agr_schemas repo before you want to use the function, as you will need to add your own schema to this repo at this point. 
 