### PR TITLE
adding tabix files to VCF generation #AGR-2323

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 ADD requirements.txt .
 
 RUN pip3 install -r requirements.txt
-RUN apt install vcftools
+RUN apt install vcftools tabix -y
 
 RUN mkdir tmp
 

--- a/src/app.py
+++ b/src/app.py
@@ -86,7 +86,7 @@ def main(vcf,
 
     click.echo('INFO:\tFiles output: ' + generated_files_folder)
     if vcf is True or all_filetypes is True:
-        click.echo('INFO:\tGenerating VCF files')
+        click.echo('INFO:\tGenerating VCF files, VCF gz files and VCF gz Tabix files')
         generate_vcf_files(generated_files_folder, fasta_sequences_folder, skip_chromosomes, config_info, upload, validate)
     if orthology is True or all_filetypes is True:
         click.echo('INFO:\tGenerating Orthology file')

--- a/src/generators/vcf_file_generator.py
+++ b/src/generators/vcf_file_generator.py
@@ -260,7 +260,16 @@ class VcfFileGenerator:
             if return_code == 0:
                 logger.info(filepath + ' compressed successfully')
             else:
-                logger.error(filepath + ' could not be compressed, please check')
+                logger.error(filepath + ' could not be compressed')
+                exit(-1)
+
+            command = 'tabix -p vcf ' + filepath + '.gz'
+            stdout, stderr, return_code = run_command(command)
+            if return_code == 0:
+                logger.info('Index file created: ' + filepath + '.gz.tbi')
+            else:
+                logger.error('Could not create index file: ' + command)
+                exit(-1)
 
             if validate_flag:
                 process_name = "1"
@@ -271,3 +280,4 @@ class VcfFileGenerator:
                     logger.info("Submitting to FMS")
                     upload.upload_process(process_name, filename, self.generated_files_folder, 'VCF', assembly, self.config_info)
                     upload.upload_process(process_name, filename + ".gz", self.generated_files_folder, 'VCF-GZ', assembly, self.config_info)
+                    upload.upload_process(process_name, filename + ".gz.tbi", self.generated_files_folder, 'VCF-GZ-TBI', assembly, self.config_info)


### PR DESCRIPTION
@scottcain once this is pulled in you can start using the index files whenever you like with your VCF JBrowse pipeline. 

@paaatrick also after this is pulled in do you mind adding a TBI button to the Downloads page for 3.2 - build?