### PR TITLE
fix(requirements): removed package Bio from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ neobolt==1.7.13
 neotime==1.7.4
 python-dateutil==2.7.3
 requests==2.21.0
-Bio==0.1.0
 wget==3.2
 biopython==1.73
 pyfaidx==0.5.5.2

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         'neotime==1.7.4',
         'python-dateutil==2.7.3',
         'requests==2.21.0',
-        'Bio==0.1.0',
         'wget==3.2',
         'biopython==1.73',
         'pyfaidx==0.5.5.2',


### PR DESCRIPTION
Bio was probably added as a wrong requirement for biopython and it's now causing issues with the loader. This PR removes it from the list of requirements. @adamjohnwright, can you verify that the file generator works without Bio?