### PR TITLE
AGR-2528 file-generator dockerhub => ECR code-changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 ARG ALLIANCE_RELEASE=latest
-FROM agrdocker/agr_base_linux_env:${ALLIANCE_RELEASE}
+ARG REG=100225593120.dkr.ecr.us-east-1.amazonaws.com
+
+FROM ${REG}/agr_base_linux_env:${ALLIANCE_RELEASE}
 
 WORKDIR /usr/src/app
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,20 @@
-build: pull
-	docker build -t agrdocker/agr_file_generator:latest .
+REG := 100225593120.dkr.ecr.us-east-1.amazonaws.com
 
-pull:
-	docker pull agrdocker/agr_base_linux_env:latest
+registry-docker-login:
+ifneq ($(shell echo ${REG} | egrep "ecr\..+\.amazonaws\.com"),)
+	@$(eval DOCKER_LOGIN_CMD=aws)
+ifneq (${AWS_PROFILE},)
+	@$(eval DOCKER_LOGIN_CMD=${DOCKER_LOGIN_CMD} --profile ${AWS_PROFILE})
+endif
+	@$(eval DOCKER_LOGIN_CMD=${DOCKER_LOGIN_CMD} ecr get-login-password | docker login -u AWS --password-stdin https://${REG})
+	${DOCKER_LOGIN_CMD}
+endif
+
+build: pull
+	docker build -t agrdocker/agr_file_generator:latest --build-arg REG=${REG} .
+
+pull: registry-docker-login
+	docker pull ${REG}/agr_base_linux_env:latest
 
 run: build
 	docker-compose up agr_file_generator

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 endif
 
 build: pull
-	docker build -t agrdocker/agr_file_generator:latest --build-arg REG=${REG} .
+	docker build -t agrlocal/agr_file_generator:latest --build-arg REG=${REG} .
 
 pull: registry-docker-login
 	docker pull ${REG}/agr_base_linux_env:latest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-This tool creates files from Alliance resources. The tool is build and testsed with python 3
+This tool creates files from Alliance resources. The tool is built and tested with python 3
 
 ## Current File Types
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.2"
 
 services:
   agr_file_generator:
-    image: agrdocker/agr_file_generator:latest
+    image: agrlocal/agr_file_generator:latest
     volumes:
       - type: volume
         source: agr_generated_files
@@ -23,7 +23,7 @@ services:
       - src/app.py
       - --gene-cross-reference
   agr_file_generator_test:
-    image: agrdocker/agr_file_generator:latest
+    image: agrlocal/agr_file_generator:latest
     volumes:
       - type: volume
         source: agr_generated_files


### PR DESCRIPTION
Makefile, Dockerfile and docker-compose updates done to move away from dockerhub and into ECR as our docker image registry (analogous to alliance-genome/agr_ansible_devops#15)