### PR TITLE
Add variant allele file AGR-2430

### DIFF
--- a/schemas/variant-allele.schema
+++ b/schemas/variant-allele.schema
@@ -1,0 +1,181 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "filetype": {
+          "type": "string"
+        },
+        "databaseVersion": {
+          "type": "string"
+        },
+        "genTime": {
+          "type": "string"
+        },
+        "sourceURL": {
+          "type": "string"
+        },
+        "stringencyFilter": {
+          "type": "string"
+        },
+        "dataFormat": {
+          "type": "string"
+        },
+        "readme": {
+          "type": "string"
+        },
+        "species": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "taxonId": {
+                "type": "string"
+              },
+              "speciesName": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "speciesName",
+              "taxonId"
+            ]
+          }
+        }
+      },
+      "required": [
+        "dataFormat",
+        "databaseVersion",
+        "filetype",
+        "genTime",
+        "sourceURL",
+        "readme",
+        "species",
+        "stringencyFilter"
+      ]
+    },
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Taxon": {
+            "type": "string"
+          },
+          "SpeciesName": {
+            "type": "string"
+          },
+          "AlleleId": {
+            "type": ["string", "null"]
+          },
+          "AlleleSymbol": {
+            "type": ["string", "null"]
+          },
+          "AlleleSynonyms": {
+            "type": "array",
+            "items": {
+              "type": ["string", "null"]
+            }
+          },
+          "VariantId": {
+            "type": ["string", "null"]
+          },
+          "VariantSymbol": {
+            "type": ["string", "null"]
+          },
+          "VariantSynonyms": {
+            "type": "array",
+            "items": {
+              "type": ["string", "null"]
+            }
+          },
+          "VariantCrossReference": {
+            "type": "array",
+            "items": {
+              "type": ["string", "null"]
+            }
+          },
+          "AlleleAssociatedGeneId": {
+            "type": "array",
+            "items": {
+             "type": ["string", "null"]
+            }
+          },
+          "AlleleAssociatedGeneSymbol": {
+            "type": "array",
+            "items": {
+               "type": ["string", "null"]
+            }
+          },
+          "VariantAffectedGeneId": {
+            "type": "array",
+            "items": {
+               "type": ["string", "null"]
+            }
+          },
+          "VariantAffectedGeneSymbol": {
+            "type": "array",
+            "items": {
+               "type": ["string", "null"]
+            }
+          },
+          "Category": {
+            "type": "string"
+          },
+          "VariantsTypeId": {
+            "type": ["string", "null"]
+          },
+          "VariantsTypeName": {
+            "type": ["string", "null"]
+          },
+          "VariantsHgvsNames": {
+            "type": ["string", "null"]
+          },
+          "Assembly": {
+            "type": ["string", "null"]
+          },
+          "StartPostiion": {
+            "type": ["number", "null"]
+          },
+          "EndPostiion": {
+            "type": ["number", "null"]
+          },
+          "SequenceOfReference": {
+            "type": ["string", "null"]
+          },
+          "SequenceOfVariant": {
+            "type": ["string", "null"]
+          },
+          "MostSevereConsequenceName": {
+            "type": "array",
+            "items": {
+               "type": ["string", "null"]
+            }
+          },
+          "VariantInformationReference": {
+            "type": "array",
+            "items": {
+               "type": ["string", "null"]
+            }
+          },
+          "HasDiseaseAnnotations": {
+            "type": "string"
+          },
+          "HasPhenotypeAnnotations": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "SpeciesName",
+          "Taxon"
+        ]
+      }
+    }
+  },
+  "required": [
+    "data",
+    "metadata"
+  ]
+}

--- a/src/app.py
+++ b/src/app.py
@@ -24,7 +24,7 @@ neo_debug_level = logging.DEBUG if config_info.config["NEO_DEBUG"] else logging.
 if config_info.config["GENERATED_FILES_FOLDER"]:
     generated_files_folder = config_info.config["GENERATED_FILES_FOLDER"]
 else:
-    generated_files_folder = os.path.join("/tmp", "agr_generated_files")
+    generated_files_folder = os.path.abspath(os.path.join(os.getcwd(), os.pardir)) + '/output'
 
 coloredlogs.install(level=debug_level,
                     fmt='%(asctime)s %(levelname)s: %(name)s:%(lineno)d: %(message)s',
@@ -41,6 +41,10 @@ logger = logging.getLogger(__name__)
 
 if config_info.config["DEBUG"]:
     logger.warning('DEBUG mode enabled!')
+
+if not os.path.isdir(generated_files_folder):
+    logger.error("Generated_files_folder: " + generated_files_folder + " does not exist")
+    exit(-1)
 
 ignore_assemblies = ["", "GRCh38", "R64-2-1", "ASM985889v3"]
 
@@ -80,7 +84,7 @@ def main(variant_allele,
          uniprot,
          human_genes_interacting_with,
          allele_gff,
-         generated_files_folder=os.path.abspath(os.path.join(os.getcwd(), os.pardir)) + '/output',
+         generated_files_folder=generated_files_folder,
          skip_chromosomes={'Unmapped_Scaffold_8_D1580_D1567'}):
 
     start_time = time.time()
@@ -129,7 +133,7 @@ def main(variant_allele,
     click.echo('File Generator finished. Elapsed time: %s' % time.strftime("%H:%M:%S", time.gmtime(elapsed_time)))
 
 
-def generate_variant_allele_file(genereated_files_folder, skip_chromosomes, config_info, upload_flag, validate_flag):
+def generate_variant_allele_file(generated_files_folder, skip_chromosomes, config_info, upload_flag, validate_flag):
     logger.info("Querying Variant Allele")
 
     variant_allele_query = '''MATCH (s:Species)<-[:FROM_SPECIES]-(a:Allele)

--- a/src/app.py
+++ b/src/app.py
@@ -12,6 +12,7 @@ from generators import (disease_file_generator,
                         gene_cross_reference_file_generator,
                         orthology_file_generator,
                         vcf_file_generator,
+                        variant_allele_file_generator,
                         uniprot_cross_reference_generator,
                         allele_gff_file_generator,
                         human_genes_interacting_with_file_generator)
@@ -53,6 +54,7 @@ taxon_id_fms_subtype_map = {"NCBITaxon:10116": "RGD",
 
 
 @click.command()
+@click.option('--variant-allele', is_flag=True, help='Generates Variant Allele files')
 @click.option('--vcf', is_flag=True, help='Generates VCF files')
 @click.option('--orthology', is_flag=True, help='Generates orthology files')
 @click.option('--disease', is_flag=True, help='Generates DAF files')
@@ -65,7 +67,8 @@ taxon_id_fms_subtype_map = {"NCBITaxon:10116": "RGD",
 @click.option('--allele-gff', is_flag=True, help='Generates an Allele based GFF file')
 @click.option('--upload', is_flag=True, help='Submits generated files to File Management System (FMS)')
 @click.option('--validate', is_flag=True, help='Validate generated file. If uploading then validates automatically')
-def main(vcf,
+def main(variant_allele,
+         vcf,
          orthology,
          disease,
          expression,
@@ -90,6 +93,9 @@ def main(vcf,
         os.makedirs(generated_files_folder, exist_ok=True)
 
     click.echo('INFO:\tFiles output: ' + generated_files_folder)
+    if variant_allele is True or all_filetypes is True:
+        click.echo('INFO:\tGenerating Variant Allele JSON and TSV files')
+        generate_variant_allele_file(generated_files_folder, skip_chromosomes, config_info, upload, validate)
     if vcf is True or all_filetypes is True:
         click.echo('INFO:\tGenerating VCF files, VCF gz files and VCF gz Tabix files')
         generate_vcf_files(generated_files_folder, skip_chromosomes, config_info, upload, validate)
@@ -121,6 +127,111 @@ def main(vcf,
     end_time = time.time()
     elapsed_time = end_time - start_time
     click.echo('File Generator finished. Elapsed time: %s' % time.strftime("%H:%M:%S", time.gmtime(elapsed_time)))
+
+
+def generate_variant_allele_file(genereated_files_folder, skip_chromosomes, config_info, upload_flag, validate_flag):
+    logger.info("Querying Variant Allele")
+
+    variant_allele_query = '''MATCH (s:Species)<-[:FROM_SPECIES]-(a:Allele {primaryKey: "MGI:3838372"})
+                              OPTIONAL MATCH (a:Allele)<-[:VARIATION]-(v:Variant)-[:LOCATED_ON]->(c:Chromosome),
+                                             (v:Variant)-[:VARIATION_TYPE]->(st:SOTerm),
+                                             (v:Variant)-[:ASSOCIATION]->(p:GenomicLocation)-[:ASSOCIATION]->(assembly:Assembly)
+                              WHERE NOT v.genomicReferenceSequence = v.genomicVariantSequence
+                                    OR v.genomicVariantSequence = ""
+                              WITH v, a, s, c, p, st, assembly
+                              OPTIONAL MATCH (v:Variant)<-[:COMPUTED_GENE]-(gene:Gene)
+                              WITH v, a, s, c, p, st, assembly, gene
+                              OPTIONAL MATCH (v:Variant)-[:ASSOCIATION]->(glc:GeneLevelConsequence)<-[:ASSOCIATION]->(gene:Gene)-[:COMPUTED_GENE]->(v:Variant)
+                              WITH v, a, s, c, p, st, assembly,
+                                   COLLECT(glc.geneLevelConsequence) AS geneConsequences,
+                                   COLLECT({id: gene.primaryKey,
+                                            symbol: gene.symbol}) AS variantAffectedGenes
+                              OPTIONAL MATCH (a:Allele)-[:IS_ALLELE_OF]->(gene:Gene)
+                              WITH v, a, s, c, p, st, assembly, geneConsequences, variantAffectedGenes,
+                                   COLLECT({id: gene.primaryKey,
+                                            symbol: gene.symbol}) AS alleleAssociatedGenes
+                              OPTIONAL MATCH (a:Allele)-[:ALSO_KNOWN_AS]-(syn:Synonym)
+                              WITH v, a, s, c, p, st, assembly, geneConsequences, variantAffectedGenes, alleleAssociatedGenes,
+                                   COLLECT(syn.primaryKey) AS alleleSyns
+                              OPTIONAL MATCH (v:Variant)-[:ALSO_KNOWN_AS]-(syn:Synonym)
+                              WITH v, a, s, c, p, st, assembly, geneConsequences, variantAffectedGenes, alleleAssociatedGenes, alleleSyns,
+                                   COLLECT(syn.primaryKey) AS variantSyns
+                              WITH v, a, s, c, p, st, assembly, geneConsequences, variantAffectedGenes, alleleAssociatedGenes, alleleSyns, variantSyns
+                              OPTIONAL MATCH (v:Variant)-[:ASSOCIATION]->(pub:Publication)
+                              WITH v, a, s, c, p, st, assembly, geneConsequences, alleleAssociatedGenes, alleleSyns, variantSyns, variantAffectedGenes,
+                                   COLLECT(pub.primaryKey) AS pubIds
+                              OPTIONAL MATCH (v:Variant)-[:CROSS_REFERENCE]->(vcr:CrossReference)
+                              WITH v, a, s, c, p, st, assembly, geneConsequences, alleleAssociatedGenes, alleleSyns, variantSyns, variantAffectedGenes, pubIds,
+                                   COLLECT(vcr.name) AS variantCrossReferences
+                              OPTIONAL MATCH (v:Variant)-[:HAS_PHENOTYPE]-(phenotype:Phenotype)
+                              WITH v, a, s, c, p, st, assembly, geneConsequences, alleleAssociatedGenes, alleleSyns, variantSyns, variantAffectedGenes, pubIds,
+                                   variantCrossReferences,
+                                   COUNT(phenotype) AS variantPhenotypeCount
+                              OPTIONAL MATCH (a:Allele)-[:HAS_PHENOTYPE]-(phenotype:Phenotype)
+                              WITH v, a, s, c, p, st, assembly, geneConsequences, alleleAssociatedGenes, alleleSyns, variantSyns, variantAffectedGenes, pubIds,
+                                   variantCrossReferences,
+                                   variantPhenotypeCount,
+                                   COUNT(phenotype) AS allelePhenotypeCount
+                              OPTIONAL MATCH (v:Variant)-[:ASSOCIATION]->(disease:DiseaseEntityJoin)
+                              WITH v, a, s, c, p, st, assembly, geneConsequences, alleleAssociatedGenes, alleleSyns, variantSyns, variantAffectedGenes, pubIds,
+                                   variantCrossReferences,
+                                   variantPhenotypeCount,
+                                   allelePhenotypeCount,
+                                   COUNT(disease) AS variantDiseaseCount
+                              OPTIONAL MATCH (a:Allele)-[:ASSOCIATION]->(disease:DiseaseEntityJoin)
+                              WITH v, a, s, c, p, st, assembly, geneConsequences, alleleAssociatedGenes, alleleSyns, variantSyns, variantAffectedGenes, pubIds,
+                                   variantCrossReferences,
+                                   variantPhenotypeCount,
+                                   allelePhenotypeCount,
+                                   variantDiseaseCount,
+                                   count(disease) AS alleleDiseaseCount
+                              OPTIONAL MATCH (a:Allele)<-[:VARIATION]-(variant:Variant)
+                              RETURN c.primaryKey AS chromosome,
+                                     variantCrossReferences,
+                                     variantPhenotypeCount,
+                                     allelePhenotypeCount,
+                                     variantDiseaseCount,
+                                     alleleDiseaseCount,
+                                     COUNT(variant) AS alleleVariantCount,
+                                     v.globalId AS globalId,
+                                     right(v.paddingLeft,1) AS paddingLeft,
+                                     v.genomicReferenceSequence AS genomicReferenceSequence,
+                                     v.genomicVariantSequence AS genomicVariantSequence,
+                                     v.hgvsNomenclature AS hgvsNomenclature,
+                                     v.dataProvider AS dataProvider,
+                                     assembly.primaryKey AS assembly,
+                                     alleleSyns,
+                                     variantSyns,
+                                     v.primaryKey as variantId,
+                                     {id: st.primaryKey,
+                                      name: st.name} AS variationType,
+                                     {symbol: a.symbol,
+                                      symbolText: a.symbolText,
+                                      id: a.primaryKey} AS allele,
+                                     pubIds,
+                                     variantAffectedGenes,
+                                     geneConsequences,
+                                     alleleAssociatedGenes,
+                                     p.start AS start,
+                                     p.end AS end,
+                                     s.name AS species,
+                                     s.primaryKey AS taxonId,
+                                     st.nameKey AS soTerm'''
+    if config_info.config["DEBUG"]:
+        logger.info(variant_allele_query)
+        start_time = time.time()
+        logger.info("Start time: %s", time.strftime("%H:%M:%S", time.gmtime(start_time)))
+
+    variant_allele_data_source = DataSource(get_neo_uri(config_info), variant_allele_query)
+    gvaf = variant_allele_file_generator.VariantAlleleFileGenerator(variant_allele_data_source,
+                                                                    generated_files_folder,
+                                                                    config_info)
+    gvaf.generate_files(skip_chromosomes=skip_chromosomes, upload_flag=upload_flag, validate_flag=validate_flag)
+
+    if config_info.config["DEBUG"]:
+        end_time = time.time()
+        logger.info("Created Variant Allele file - End time: %s", time.strftime("%H:%M:%S", time.gmtime(end_time)))
+        logger.info("Time Elapsed: %s", time.strftime("%H:%M:%S", time.gmtime(end_time - start_time)))
 
 
 def generate_vcf_file(assembly, generated_files_folder, skip_chromosomes, config_info, upload_flag, validate_flag):

--- a/src/app.py
+++ b/src/app.py
@@ -84,7 +84,7 @@ def main(variant_allele,
          uniprot,
          human_genes_interacting_with,
          allele_gff,
-         generated_files_folder=generated_files_folder,
+         generated_files_folder=os.path.abspath(os.path.join(os.getcwd(), os.pardir)) + '/output',
          skip_chromosomes={'Unmapped_Scaffold_8_D1580_D1567'}):
 
     start_time = time.time()

--- a/src/app.py
+++ b/src/app.py
@@ -42,9 +42,9 @@ logger = logging.getLogger(__name__)
 if config_info.config["DEBUG"]:
     logger.warning('DEBUG mode enabled!')
 
-if not os.path.isdir(generated_files_folder):
-    logger.error("Generated_files_folder: " + generated_files_folder + " does not exist")
-    exit(-1)
+#if not os.path.isdir(generated_files_folder):
+#    logger.error("Generated_files_folder: " + generated_files_folder + " does not exist")
+#    exit(-1)
 
 ignore_assemblies = ["", "GRCh38", "R64-2-1", "ASM985889v3"]
 

--- a/src/app.py
+++ b/src/app.py
@@ -24,7 +24,7 @@ neo_debug_level = logging.DEBUG if config_info.config["NEO_DEBUG"] else logging.
 if config_info.config["GENERATED_FILES_FOLDER"]:
     generated_files_folder = config_info.config["GENERATED_FILES_FOLDER"]
 else:
-    generated_files_folder = os.path.abspath(os.path.join(os.getcwd(), os.pardir)) + '/output'
+    generated_files_folder = os.path.join("/tmp", "agr_generated_files")
 
 coloredlogs.install(level=debug_level,
                     fmt='%(asctime)s %(levelname)s: %(name)s:%(lineno)d: %(message)s',

--- a/src/generators/variant_allele_file_generator.py
+++ b/src/generators/variant_allele_file_generator.py
@@ -168,5 +168,5 @@ class VariantAlleleFileGenerator:
             json_validator.JsonValidator(filepath_json, 'variant-allele').validateJSON()
             if upload_flag:
                 logger.info("Submitting to FMS")
-                upload.upload_process(process_name, filepath_tsv, self.generated_files_folder, 'VARIANT-ALLELE', 'COMBINED', self.config_info)
-                upload.upload_process(process_name, filepath_json, self.generated_files_folder, 'VARIANT-ALLLELE-JSON', 'COMBINED', self.config_info)
+                upload.upload_process(process_name, filename + ".tsv", self.generated_files_folder, 'VARIANT-ALLELE', 'COMBINED', self.config_info)
+                upload.upload_process(process_name, filename + ".json", self.generated_files_folder, 'VARIANT-ALLLELE-JSON', 'COMBINED', self.config_info)

--- a/src/generators/variant_allele_file_generator.py
+++ b/src/generators/variant_allele_file_generator.py
@@ -1,16 +1,14 @@
 import os
-import time
-import json
 import sys
-from collections import defaultdict, OrderedDict
-from functools import partial
-from operator import itemgetter
-from common import run_command
-from validators import vcf_validator
+import json
+import csv
+
 import logging
 import upload
 
+from headers import create_header
 from .vcf_file_generator import VcfFileGenerator
+from validators import json_validator
 
 sys.path.append('../')
 
@@ -24,15 +22,63 @@ class VariantAlleleFileGenerator:
         self.config_info = config_info
         self.generated_files_folder = generated_files_folder
 
+    @classmethod
+    def _generate_header(cls, config_info, taxon_ids, data_format):
+        """
+          :param config_info:
+          :param taxon_ids:
+          :return:
+        """
+
+        return create_header('Variant/Allele',
+                             config_info.config['RELEASE_VERSION'],
+                             taxon_ids=taxon_ids,
+                             config_info=config_info,
+                             data_format=data_format)
+
     def generate_files(self, skip_chromosomes=(), upload_flag=False, validate_flag=False):
+
+        fields = ['Taxon',
+                  'SpeciesName',
+                  'AlleleId',
+                  'AlleleSymbol',
+                  'AlleleSynonyms',
+                  'VariantId',
+                  'VariantSymbol',
+                  'VariantSynonyms',
+                  'VariantCrossReferences',
+                  'AlleleAssociatedGeneId',
+                  'AlleleAssociatedGeneSymbol',
+                  'VariantAffectedGeneId',
+                  'VariantAffectedGeneSymbol',
+                  'Category',
+                  'VariantsTypeId',
+                  'VariantsTypeName',
+                  'VariantsHgvsNames',
+                  'Assembly',
+                  'Chromosome',
+                  'StartPostiion',
+                  'EndPostiion',
+                  'SequenceOfReference',
+                  'SequenceOfVariant',
+                  'MostSevereConsequenceName',
+                  'VariantInformationReference',
+                  'HasDiseaseAnnotations',
+                  'HasPhenotypeAnnotations']
+
         filename = 'variant-allele-' + self.config_info.config['RELEASE_VERSION']
-        filepath = os.path.join(self.generated_files_folder, filename)
+        filepath_stub = os.path.join(self.generated_files_folder, filename)
+        filepath_json = filepath_stub + ".json"
+        filepath_tsv = filepath_stub + ".tsv"
+
         logger.info('Generating VARIANT_ALLELE File')
 
+        taxon_ids = set()
         documents = []
         for variant_allele in self.variant_alleles:
             vcf_generator = VcfFileGenerator(self.variant_alleles, self.generated_files_folder, self.config_info)
-            VcfFileGenerator._adjust_variant(vcf_generator, variant_allele)
+            if variant_allele['start']:
+                VcfFileGenerator._adjust_variant(vcf_generator, variant_allele)
             allele_associated_gene_ids = []
             allele_associated_gene_symbols = []
             if variant_allele['alleleAssociatedGenes'] is not None:
@@ -69,39 +115,58 @@ class VariantAlleleFileGenerator:
             if variant_allele['alleleVariantCount'] > 0:
                 category = category + " with " + str(variant_allele['alleleVariantCount']) + " known variants"
 
-            document = {'species': variant_allele['species'],
-                        'species_id': variant_allele['taxonId'],
-                        'allele_id': variant_allele['allele']['id'] if variant_allele['allele'] else None,
-                        'allele_symbol': variant_allele['allele']['symbol'] if variant_allele['allele'] else None,
-                        'allele_synonyms': variant_allele['alleleSyns'],
-                        'variant_id': variant_allele['variantId'],
-                        'variant_symbol': variant_symbol,
-                        'variant_synonyms': variant_allele['variantSyns'],
-                        'variant_cross_reference': variant_allele['variantCrossReferences'],
-                        'allele_associated_gene_id': allele_associated_gene_ids,
-                        'allele_associated_gene_symbol': allele_associated_gene_symbols,
-                        'variant_affected_gene_id': variant_affected_gene_ids,
-                        'variant_affected_gene_symbol': variant_affected_gene_symbols,
-                        'category': category,
-                        'variants_type_id': variant_allele['variationType']['id'] if variant_allele['variationType'] else None,
-                        'variants_type_name': variant_allele['variationType']['name'] if variant_allele['variationType'] else None,
-                        'variants_hgvs_names': variant_allele['hgvsNomenclature'],
-                        'assembly': variant_allele['assembly'],
-                        'chromosome': variant_allele['chromosome'],
-                        'start_postiion': variant_allele['start'],
-                        'end_postiion': variant_allele['end'],
-                        'sequence_of_reference': variant_allele['genomicReferenceSequence'],
-                        'sequence_of_variant': variant_allele['genomicVariantSequence'],
-                        'most_severe_consequence_name': variant_allele['geneConsequences'],
-                        'variant_information_reference': variant_allele['pubIds'],
-                        'has_disease_annotations': has_disease,
-                        'has_phenotype_annotations': has_phenotype}
+            taxon_ids.add(variant_allele['taxonId'])
+
+            document = {'Taxon': variant_allele['taxonId'],
+                        'SpeciesName': variant_allele['species'],
+                        'AlleleId': variant_allele['allele']['id'] if variant_allele['allele'] else None,
+                        'AlleleSymbol': variant_allele['allele']['symbol'] if variant_allele['allele'] else None,
+                        'AlleleSynonyms': variant_allele['alleleSyns'],
+                        'VariantId': variant_allele['variantId'],
+                        'VariantSymbol': variant_symbol,
+                        'VariantSynonyms': variant_allele['variantSyns'],
+                        'VariantCrossReferences': variant_allele['variantCrossReferences'],
+                        'AlleleAssociatedGeneId': allele_associated_gene_ids,
+                        'AlleleAssociatedGeneSymbol': allele_associated_gene_symbols,
+                        'VariantAffectedGeneId': variant_affected_gene_ids,
+                        'VariantAffectedGeneSymbol': variant_affected_gene_symbols,
+                        'Category': category,
+                        'VariantsTypeId': variant_allele['variationType']['id'] if variant_allele['variationType'] else None,
+                        'VariantsTypeName': variant_allele['variationType']['name'] if variant_allele['variationType'] else None,
+                        'VariantsHgvsNames': variant_allele['hgvsNomenclature'],
+                        'Assembly': variant_allele['assembly'],
+                        'Chromosome': variant_allele['chromosome'],
+                        'StartPostiion': variant_allele['start'],
+                        'EndPostiion': variant_allele['end'],
+                        'SequenceOfReference': variant_allele['genomicReferenceSequence'],
+                        'SequenceOfVariant': variant_allele['genomicVariantSequence'],
+                        'MostSevereConsequenceName': variant_allele['geneConsequences'],
+                        'VariantInformationReference': variant_allele['pubIds'],
+                        'HasDiseaseAnnotations': has_disease,
+                        'HasPhenotypeAnnotations': has_phenotype}
             documents.append(document)
+
+        with open(filepath_json, 'w') as f:
+            contents = {'metadata': self._generate_header(self.config_info, taxon_ids, 'json'),
+                        'data': documents}
+            json.dump(contents, f)
+
+        for document in documents:
+            for key in document:
+                if isinstance(document[key], list):
+                    document[key] = ','.join(document[key])
+
+        with open(filepath_tsv, 'w') as f:
+            f.write(self._generate_header(self.config_info, taxon_ids, 'tsv'))
+            writer = csv.DictWriter(f, delimiter='\t', fieldnames=fields, lineterminator="\n")
+            writer.writeheader()
+            writer.writerows(documents)
 
         if validate_flag:
             process_name = "1"
-            filepath = os.path.join(self.generated_files_folder, filename)
+            logger.info("validating JSON file")
+            json_validator.JsonValidator(filepath_json, 'variant-allele').validateJSON()
             if upload_flag:
                 logger.info("Submitting to FMS")
-                upload.upload_process(process_name, filename + '.tsv', self.generated_files_folder, 'VARIANT-ALLELE', 'TSV', self.config_info)
-                upload.upload_process(process_name, filepath + ".json", self.generated_files_folder, 'VARIANT-ALLLELE-JSON', 'JSON', self.config_info)
+                upload.upload_process(process_name, filepath_tsv, self.generated_files_folder, 'VARIANT-ALLELE', 'COMBINED', self.config_info)
+                upload.upload_process(process_name, filepath_json, self.generated_files_folder, 'VARIANT-ALLLELE-JSON', 'COMBINED', self.config_info)

--- a/src/generators/variant_allele_file_generator.py
+++ b/src/generators/variant_allele_file_generator.py
@@ -1,0 +1,107 @@
+import os
+import time
+import json
+import sys
+from collections import defaultdict, OrderedDict
+from functools import partial
+from operator import itemgetter
+from common import run_command
+from validators import vcf_validator
+import logging
+import upload
+
+from .vcf_file_generator import VcfFileGenerator
+
+sys.path.append('../')
+
+logger = logging.getLogger(name=__name__)
+
+
+class VariantAlleleFileGenerator:
+
+    def __init__(self, variant_alleles, generated_files_folder, config_info):
+        self.variant_alleles = variant_alleles
+        self.config_info = config_info
+        self.generated_files_folder = generated_files_folder
+
+    def generate_files(self, skip_chromosomes=(), upload_flag=False, validate_flag=False):
+        filename = 'variant-allele-' + self.config_info.config['RELEASE_VERSION']
+        filepath = os.path.join(self.generated_files_folder, filename)
+        logger.info('Generating VARIANT_ALLELE File')
+
+        documents = []
+        for variant_allele in self.variant_alleles:
+            vcf_generator = VcfFileGenerator(self.variant_alleles, self.generated_files_folder, self.config_info)
+            VcfFileGenerator._adjust_variant(vcf_generator, variant_allele)
+            allele_associated_gene_ids = []
+            allele_associated_gene_symbols = []
+            if variant_allele['alleleAssociatedGenes'] is not None:
+                for allele_associated_genes in variant_allele['alleleAssociatedGenes']:
+                    if allele_associated_genes['id']:
+                        allele_associated_gene_ids.append(allele_associated_genes['id'])
+                    if allele_associated_genes['symbol']:
+                        allele_associated_gene_symbols.append(allele_associated_genes['symbol'])
+
+            variant_affected_gene_ids = []
+            variant_affected_gene_symbols = []
+            if variant_allele['variantAffectedGenes']:
+                for variant_affected_genes in variant_allele['variantAffectedGenes']:
+                    if variant_affected_genes['id']:
+                        variant_affected_gene_ids.append(variant_affected_genes['id'])
+                    if variant_affected_genes['symbol']:
+                        variant_affected_gene_symbols.append(variant_affected_genes['symbol'])
+
+            variant_symbol = variant_allele['variantId']
+            if variant_symbol:
+                variant_id_parts = variant_allele['variantId'].split(':g.')
+                if len(variant_id_parts) == 2:
+                    variant_symbol = variant_allele['chromosome'] + ":" + variant_id_parts[1]
+
+            has_disease = "-"
+            if variant_allele['alleleDiseaseCount'] + variant_allele['variantDiseaseCount'] > 0:
+                has_disease = "yes"
+
+            has_phenotype = "-"
+            if variant_allele['allelePhenotypeCount'] + variant_allele['variantPhenotypeCount'] > 0:
+                has_phenotype = "yes"
+
+            category = "allele"
+            if variant_allele['alleleVariantCount'] > 0:
+                category = category + " with " + str(variant_allele['alleleVariantCount']) + " known variants"
+
+            document = {'species': variant_allele['species'],
+                        'species_id': variant_allele['taxonId'],
+                        'allele_id': variant_allele['allele']['id'] if variant_allele['allele'] else None,
+                        'allele_symbol': variant_allele['allele']['symbol'] if variant_allele['allele'] else None,
+                        'allele_synonyms': variant_allele['alleleSyns'],
+                        'variant_id': variant_allele['variantId'],
+                        'variant_symbol': variant_symbol,
+                        'variant_synonyms': variant_allele['variantSyns'],
+                        'variant_cross_reference': variant_allele['variantCrossReferences'],
+                        'allele_associated_gene_id': allele_associated_gene_ids,
+                        'allele_associated_gene_symbol': allele_associated_gene_symbols,
+                        'variant_affected_gene_id': variant_affected_gene_ids,
+                        'variant_affected_gene_symbol': variant_affected_gene_symbols,
+                        'category': category,
+                        'variants_type_id': variant_allele['variationType']['id'] if variant_allele['variationType'] else None,
+                        'variants_type_name': variant_allele['variationType']['name'] if variant_allele['variationType'] else None,
+                        'variants_hgvs_names': variant_allele['hgvsNomenclature'],
+                        'assembly': variant_allele['assembly'],
+                        'chromosome': variant_allele['chromosome'],
+                        'start_postiion': variant_allele['start'],
+                        'end_postiion': variant_allele['end'],
+                        'sequence_of_reference': variant_allele['genomicReferenceSequence'],
+                        'sequence_of_variant': variant_allele['genomicVariantSequence'],
+                        'most_severe_consequence_name': variant_allele['geneConsequences'],
+                        'variant_information_reference': variant_allele['pubIds'],
+                        'has_disease_annotations': has_disease,
+                        'has_phenotype_annotations': has_phenotype}
+            documents.append(document)
+
+        if validate_flag:
+            process_name = "1"
+            filepath = os.path.join(self.generated_files_folder, filename)
+            if upload_flag:
+                logger.info("Submitting to FMS")
+                upload.upload_process(process_name, filename + '.tsv', self.generated_files_folder, 'VARIANT-ALLELE', 'TSV', self.config_info)
+                upload.upload_process(process_name, filepath + ".json", self.generated_files_folder, 'VARIANT-ALLLELE-JSON', 'JSON', self.config_info)


### PR DESCRIPTION
This code adds a FMS type VARIANT-ALLELE  (JSON) and VARIANT-ALLELE-JSON with subtype COMBINED for each. 

I have looked at the data and it looks good to me. I think it is at least very close to correct. I think it should be pulled in and then when the FMS is storing the file I can make what ever changes are required for 4.0 release. 