### PR TITLE
Getting the Source from the cross ref not dataprovider now AGR-2574

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -257,6 +257,7 @@ def generate_disease_file(generated_files_folder, config_info, taxon_id_fms_subt
                                               "implicated_via_orthology",
                                               "biomarker_via_orthology"]
                    MATCH (dej:Association:DiseaseEntityJoin)-[:EVIDENCE]->(pj:PublicationJoin),
+                         (dej:DiseaseEntityJoin)-[:ANNOTATION_SOURCE_CROSS_REFERENCE]->(ascr:CrossReference),
                          (p:Publication)-[:ASSOCIATION]->(pj:PublicationJoin)-[:ASSOCIATION]->(ec:Ontology:ECOTerm)
                    OPTIONAL MATCH (object:Gene)-[:ASSOCIATION]->(dej:Association:DiseaseEntityJoin)<-[:ASSOCIATION]-(otherAssociatedEntity)
                    OPTIONAL MATCH (pj:PublicationJoin)-[:MODEL_COMPONENT|PRIMARY_GENETIC_ENTITY]-(inferredFromEntity)
@@ -285,7 +286,7 @@ def generate_disease_file(generated_files_folder, config_info, taxon_id_fms_subt
                                             otherAssociatedEntityID: otherAssociatedEntity.primaryKey}) as evidence,
                           REDUCE(t = "1900-01-01", c IN collect(left(pj.dateAssigned, 10)) | CASE WHEN c > t THEN c ELSE t END) AS dateAssigned,
                           ///takes most recent date
-                          dej.dataProvider AS dataProvider'''
+                          ascr.displayName AS sourceDisplayName'''
 
     if config_info.config["DEBUG"]:
         logger.info("Disease Association Query: ")

--- a/src/generators/disease_file_generator.py
+++ b/src/generators/disease_file_generator.py
@@ -183,7 +183,7 @@ class DiseaseFileGenerator:
                                                           # genetic_sex,
                                                           pub_id,
                                                           datetime.strptime(date_str, "%Y-%m-%d").strftime("%Y%m%d"),
-                                                          disease_association["dataProvider"]]))
+                                                          disease_association["sourceDisplayName"]]))
                 processed_association_tsv = processed_association.copy()
                 processed_association_tsv["WithOrthologs"] = "|".join(set(disease_association["withOrthologs"])) if len(disease_association["withOrthologs"]) > 0 else ""
 


### PR DESCRIPTION
I was originally using DataProvider. I don't remember seeing the associated Cross-reference node when writing the query initially but now I see where the UI would be pulling the source. With this pull request, we will be using the same information to populate the source column.