### PR TITLE
Making it so that we are submitting bgzipped files to FMS via VCF Datatype - AGR-2642

### DIFF
--- a/src/generators/vcf_file_generator.py
+++ b/src/generators/vcf_file_generator.py
@@ -283,6 +283,5 @@ class VcfFileGenerator:
                 validator.validate_vcf()
                 if upload_flag:
                     logger.info("Submitting to FMS")
-                    upload.upload_process(process_name, filename, self.generated_files_folder, 'VCF', assembly, self.config_info)
-                    upload.upload_process(process_name, filename + ".gz", self.generated_files_folder, 'VCF-GZ', assembly, self.config_info)
+                    upload.upload_process(process_name, filename + ".gz", self.generated_files_folder, 'VCF', assembly, self.config_info)
                     upload.upload_process(process_name, filename + ".gz.tbi", self.generated_files_folder, 'VCF-GZ-TBI', assembly, self.config_info)


### PR DESCRIPTION
As discussed we will now stop using the FMS datatype VCF-GZ. Instead, the File Generator will be uploading bgzipped files to the FMS with datatype VCF.

@scottcain once these changes go through, you will be able to test to see if the TBI files work with the VCF files. If not feel free to add another ticket.