### PR TITLE
Variant cross ref fix AGR-2430

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -162,7 +162,7 @@ def generate_variant_allele_species_file(species_id, generated_files_folder, ski
                               OPTIONAL MATCH (v:Variant)-[:ASSOCIATION]->(pub:Publication)
                               WITH v, a, s, c, p, st, assembly, geneConsequences, alleleAssociatedGenes, alleleSyns, variantSyns, variantAffectedGenes,
                                    COLLECT(pub.primaryKey) AS pubIds
-                              OPTIONAL MATCH (v:Variant)-[:CROSS_REFERENCE]->(vcr:CrossReference)
+                              OPTIONAL MATCH (v:Variant)-[:CROSS_REFERENCE]->(vcr:CrossReference)<-[:CROSS_REFERENCE]-(a:Allele)
                               WITH v, a, s, c, p, st, assembly, geneConsequences, alleleAssociatedGenes, alleleSyns, variantSyns, variantAffectedGenes, pubIds,
                                    COLLECT(vcr.name) AS variantCrossReferences
                               OPTIONAL MATCH (v:Variant)-[:HAS_PHENOTYPE]-(phenotype:Phenotype)


### PR DESCRIPTION
The issue is that it was showing all the cross-references off the variant when what is wanted is only the cross-references off of the variant that is also off of the allele. 